### PR TITLE
Improve README instructions for API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,15 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Setze anschließend den OpenAI API‑Key über die Umgebungsvariable `OPENAI_API_KEY`.
+Der Zugriff auf ChatGPT erfordert einen gültigen OpenAI API‑Key. Dieser muss
+als Umgebungsvariable `OPENAI_API_KEY` vor dem Start gesetzt sein, zum
+Beispiel:
+
+```bash
+export OPENAI_API_KEY=<dein-geheimer-key>
+```
+
+Das Programm liest diese Variable beim Aufruf aus.
 
 ## Verwendung
 


### PR DESCRIPTION
## Summary
- document how to set `OPENAI_API_KEY`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685e426553d08321b88758f7c9e4e3aa