### PR TITLE
Fix OpenAI requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-openai>=1.0.0
+openai>=0.28
 requests>=2.0
 python-dateutil>=2.8


### PR DESCRIPTION
## Summary
- relax `openai` version requirement to use a released version

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685e43578ed88321b887cd868ec9133c