### PR TITLE
Resolve pandas dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 openai>=0.10.5
-pandas>=1.1.5
+pandas>=1.2.3
 requests>=2.0
 python-dateutil>=2.8

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,10 +1,12 @@
 """Natural language interface for Südtirol's transit system."""
 
-from . import config, efa_api, formatter, nlp_parser
+from importlib import import_module
 
-__all__ = [
-    "config",
-    "efa_api",
-    "formatter",
-    "nlp_parser",
-]
+__all__ = ["config", "efa_api", "formatter", "nlp_parser"]
+
+
+def __getattr__(name: str):
+    """Lazily import submodules on first access."""
+    if name in __all__:
+        return import_module(f"{__name__}.{name}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- bump pandas requirement to `>=1.2.3` to satisfy openai
- lazily load submodules to avoid unnecessary imports at package import time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e457f63a08321b101641530f6756a