### PR TITLE
Add install script and main example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # suedtirolmobilAI
+
+## Quickstart
+
+The script `install_and_run.sh` installs the Python dependencies (using `python3 -m pip` if a `requirements.txt` file is present) and then runs `src/main.py`.
+
+### Usage
+
+```bash
+bash install_and_run.sh "Deine Anfrage"
+```

--- a/install_and_run.sh
+++ b/install_and_run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Install dependencies if a requirements file exists
+if [ -f requirements.txt ]; then
+    echo "Installing Python dependencies..."
+    python3 -m pip install -r requirements.txt
+fi
+
+# Execute the main program with all passed arguments
+python3 src/main.py "$@"

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,11 @@
+import sys
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 src/main.py <query>")
+        return
+    query = sys.argv[1]
+    print(f'Du hast nach "{query}" gefragt.')
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple `src/main.py`
- create `install_and_run.sh` for installing deps and running the script
- document the usage in `README.md`
- use `python3 -m pip` to install deps

## Testing
- `bash install_and_run.sh "Test"`


------
https://chatgpt.com/codex/tasks/task_e_686270e111648321be8da5faeee874b0