### PR TITLE
Update dependencies and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ pip install -r requirements.txt
 python -m spacy download de_core_news_sm  # optional
 ```
 
+If you upgrade to a newer release of this project, reinstall the dependencies
+by running the above command again.
+
 ## Running the server
 
 Start the API using `uvicorn`:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-fastapi
+fastapi>=0.110
 requests
 spacy
+pydantic>=2.0


### PR DESCRIPTION
## Summary
- pin FastAPI to >=0.110 and add pydantic>=2.0
- add upgrade instructions to README
- install dependencies during tests to verify compatibility

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864d4f67f348321b9f647f1011cf4c3