### PR TITLE
Update README server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ by running the above command again.
 
 ## Running the server
 
-Start the API using `uvicorn`:
+Start the API using `uvicorn` so that code changes are picked up automatically:
 
 ```bash
 uvicorn src.main:app --reload
 ```
+
+Running `python -m src.main` also starts the server but does not enable
+auto‑reloading.
 
 ## Testing
 

--- a/src/main.py
+++ b/src/main.py
@@ -14,7 +14,8 @@ def search(req: SearchRequest):
         raise HTTPException(status_code=400, detail="No parameters extracted")
     return efa_api.search_efa(params)
 
-if __name__ == "__main__":
+# Run via ``python -m src.main`` for debugging without auto-reload.
+if __name__ == "__main__" and __package__:
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)
 


### PR DESCRIPTION
## Summary
- stress `uvicorn src.main:app --reload` in README
- limit `__main__` execution in `src/main.py` to `python -m src.main`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864d53932b88321b6284d0871ee89d2