### PR TITLE
Add example request to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ uvicorn src.main:app --reload
 Running `python -m src.main` also starts the server but does not enable
 auto‑reloading.
 
+
+## Example request
+
+After the server is running, you can query it with a POST request:
+
+```bash
+curl -X POST http://localhost:8000/search \
+     -H 'Content-Type: application/json' \
+     -d '{"text": "Wie komme ich von Bozen nach Meran um 14:30?"}'
+```
+
+The response JSON mirrors the data returned by the underlying EFA service. Important fields include:
+
+- `from_stop`: the detected origin stop
+- `to_stop`: the detected destination stop
+- `time`: the requested departure time, if any
+- `trips`: a list of connection options with departure and arrival details
+
 ## Testing
 
 Run the unit tests with `pytest`:


### PR DESCRIPTION
## Summary
- document a sample curl invocation to query the API
- explain important fields returned in the JSON response

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864d8feaaac8321a0aa9524798d341e