### PR TITLE
Update README with EFA endpoint clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ uvicorn src.main:app --reload
 Running `python -m src.main` also starts the server but does not enable
 auto‑reloading.
 
+## Configuration
+
+The Mentz‑EFA endpoint can be configured via the `EFA_BASE_URL`
+environment variable. By default this project uses
+`https://efa-api.asw.io`, an aggregator for the official
+South Tyrol endpoint `https://efa.sta.bz.it/apb/`. You can point the
+API to any compatible service by setting `EFA_BASE_URL`.
+
+```bash
+EFA_BASE_URL=https://example.com/efa uvicorn src.main:app --reload
+```
+
 ## Testing
 
 Run the unit tests with `pytest`:


### PR DESCRIPTION
## Summary
- add note that the standard South Tyrol EFA endpoint is `https://efa.sta.bz.it/apb/`
- clarify that `https://efa-api.asw.io` is an aggregator used by default

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864d909a8ec8321aae56599f94d1532