### PR TITLE
Add uvicorn dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ pip install -r requirements.txt
 python -m spacy download de_core_news_sm  # optional
 ```
 
+This also installs `uvicorn`, which runs the FastAPI server.
+
 If you upgrade to a newer release of this project, reinstall the dependencies
 by running the above command again.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi>=0.110
 requests
 spacy
 pydantic>=2.0
+uvicorn


### PR DESCRIPTION
## Summary
- document that uvicorn is installed with the dependencies
- add uvicorn to requirements.txt so running `uvicorn` works after install

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864db4052ac8321a49548631597f506