### PR TITLE
Add Python 3 mention to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# Requires Python 3
 fastapi>=0.110
 requests
 spacy


### PR DESCRIPTION
## Summary
- note that Python 3 is required by adding a comment to `requirements.txt`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864df06722c83219a07f89b5afdf4a0