### PR TITLE
Update default EFA endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ auto‑reloading.
 ## Configuration
 
 The Mentz‑EFA endpoint can be configured via the `EFA_BASE_URL`
-environment variable. By default this project uses
-`https://efa-api.asw.io`, an aggregator for the official
+environment variable. By default this project uses the official
 South Tyrol endpoint `https://efa.sta.bz.it/apb/`. You can point the
 API to any compatible service by setting `EFA_BASE_URL`.
 

--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -2,7 +2,7 @@ import os
 from typing import Dict, Any
 import requests
 
-BASE_URL = os.environ.get("EFA_BASE_URL", "https://efa-api.asw.io")
+BASE_URL = os.environ.get("EFA_BASE_URL", "https://efa.sta.bz.it/apb/")
 
 
 def search_efa(params: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- use the official `efa.sta.bz.it` endpoint by default
- update README to match the new default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864e36865ac83218ad8ac340b48bcce