### PR TITLE
Fix EFA API request

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ auto‑reloading.
 
 The Mentz‑EFA endpoint can be configured via the `EFA_BASE_URL`
 environment variable. By default this project uses the official
-South Tyrol endpoint `https://efa.sta.bz.it/apb/`. You can point the
+South Tyrol endpoint `https://efa.sta.bz.it/apb`. You can point the
 API to any compatible service by setting `EFA_BASE_URL`.
 
 ```bash
-EFA_BASE_URL=https://efa.sta.bz.it/apb/ uvicorn src.main:app --reload
+EFA_BASE_URL=https://efa.sta.bz.it/apb uvicorn src.main:app --reload
 ```
 
 =======

--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -2,7 +2,7 @@ import os
 from typing import Dict, Any
 import requests
 
-BASE_URL = os.environ.get("EFA_BASE_URL", "https://efa.sta.bz.it/apb/")
+BASE_URL = os.environ.get("EFA_BASE_URL", "https://efa.sta.bz.it/apb")
 
 
 def search_efa(params: Dict[str, Any]) -> Dict[str, Any]:
@@ -18,8 +18,22 @@ def search_efa(params: Dict[str, Any]) -> Dict[str, Any]:
     dict
         JSON response from the API.
     """
-    url = f"{BASE_URL}/".rstrip('/')
-    response = requests.get(url, params=params, timeout=10)
+    url = f"{BASE_URL}/XML_TRIP_REQUEST2"
+
+    efa_params = {
+        "name_origin": params.get("from_stop"),
+        "type_origin": "any",
+        "name_destination": params.get("to_stop"),
+        "type_destination": "any",
+        "outputFormat": "JSON",
+        "calcNumberOfTrips": 1,
+    }
+
+    time = params.get("time")
+    if time:
+        efa_params["itdTime"] = time
+
+    response = requests.get(url, params=efa_params, timeout=10)
     response.raise_for_status()
     try:
         return response.json()

--- a/tests/test_efa_api.py
+++ b/tests/test_efa_api.py
@@ -6,8 +6,15 @@ from src import efa_api
 def test_search_efa_calls_requests(mock_get):
     mock_get.return_value.status_code = 200
     mock_get.return_value.json.return_value = {'ok': True}
-    params = {'from': 'Bozen', 'to': 'Meran'}
+    params = {'from_stop': 'Bozen', 'to_stop': 'Meran', 'time': '08:00'}
     result = efa_api.search_efa(params)
+
     mock_get.assert_called_once()
+    url, kwargs = mock_get.call_args
+    assert url[0].endswith('/XML_TRIP_REQUEST2')
+    efa_params = kwargs['params']
+    assert efa_params['name_origin'] == 'Bozen'
+    assert efa_params['name_destination'] == 'Meran'
+    assert efa_params['itdTime'] == '08:00'
     assert result == {'ok': True}
 


### PR DESCRIPTION
## Summary
- adjust default endpoint URL in `efa_api`
- build request according to EFA XML API documentation
- update tests to expect `XML_TRIP_REQUEST2` parameters
- document updated endpoint configuration

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864e88829e48321b80e1db34d409c96