### PR TITLE
Improve docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This project provides a small FastAPI service that parses natural language
 queries for public transport connections and forwards them to a Mentz-EFA
 backend.
 
+For a detailed overview of the available Mentz-EFA endpoints, see
+[docs/EFA_XML_API.md](docs/EFA_XML_API.md).
+
 ## Installation
 
 Run the provided `install.sh` script for a one-click setup. The
@@ -46,7 +49,6 @@ API to any compatible service by setting `EFA_BASE_URL`.
 EFA_BASE_URL=https://efa.sta.bz.it/apb uvicorn src.main:app --reload
 ```
 
-=======
 
 ## Example request
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-fastapi
+fastapi>=0.110
 requests
 spacy
-pydantic
+pydantic>=2.0
 uvicorn
+httpx

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from src.main import app
+
+client = TestClient(app)
+
+@patch('src.main.efa_api.search_efa')
+@patch('src.main.nlp_parser.parse_query')
+def test_search_endpoint(mock_parse, mock_search):
+    mock_parse.return_value = {'from_stop': 'Bozen', 'to_stop': 'Meran', 'time': '12:00'}
+    mock_search.return_value = {'trips': []}
+    response = client.post('/search', json={'text': 'Bozen nach Meran um 12:00'})
+    assert response.status_code == 200
+    assert response.json() == {'trips': []}
+    mock_parse.assert_called_once_with('Bozen nach Meran um 12:00')
+    mock_search.assert_called_once()
+


### PR DESCRIPTION
## Summary
- pin FastAPI and Pydantic versions
- add httpx dependency for testing
- link to EFA documentation in README
- remove stray formatting line from README
- add integration test for `/search` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863d6236e70832186078b237ba795c2