### PR TITLE
Add stopfinder lookup before trip request

### DIFF
--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -1,8 +1,52 @@
 import os
-from typing import Dict, Any
+from typing import Dict, Any, List, Optional
 import requests
 
 BASE_URL = os.environ.get("EFA_BASE_URL", "https://efa.sta.bz.it/apb")
+
+
+def _get_best_stop_name(query: str) -> str:
+    """Lookup a stop using the StopFinder request and return the best match.
+
+    If the request fails or returns no usable result, the original query is
+    returned unchanged.
+    """
+    url = f"{BASE_URL}/XML_STOPFINDER_REQUEST"
+    params = {
+        "odvSugMacro": 1,
+        "name_sf": query,
+        "outputFormat": "JSON",
+    }
+
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        points: List[Dict[str, Any]] = (
+            data.get("stopFinder", {})
+            .get("points", {})
+            .get("point", [])
+        )
+        if isinstance(points, dict):
+            points = [points]
+
+        best: Optional[Dict[str, Any]] = None
+        best_quality = -1
+        for p in points:
+            try:
+                quality = int(p.get("quality", 0))
+            except (TypeError, ValueError):
+                quality = 0
+            if quality > best_quality:
+                best_quality = quality
+                best = p
+
+        if best and best.get("name"):
+            return best["name"]
+    except Exception:
+        pass
+
+    return query
 
 
 def search_efa(params: Dict[str, Any]) -> Dict[str, Any]:
@@ -20,10 +64,17 @@ def search_efa(params: Dict[str, Any]) -> Dict[str, Any]:
     """
     url = f"{BASE_URL}/XML_TRIP_REQUEST2"
 
+    from_stop = params.get("from_stop")
+    if from_stop:
+        from_stop = _get_best_stop_name(from_stop)
+    to_stop = params.get("to_stop")
+    if to_stop:
+        to_stop = _get_best_stop_name(to_stop)
+
     efa_params = {
-        "name_origin": params.get("from_stop"),
+        "name_origin": from_stop,
         "type_origin": "any",
-        "name_destination": params.get("to_stop"),
+        "name_destination": to_stop,
         "type_destination": "any",
         "outputFormat": "JSON",
         "calcNumberOfTrips": 1,

--- a/tests/test_efa_api.py
+++ b/tests/test_efa_api.py
@@ -1,18 +1,51 @@
 import sys, os; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from src import efa_api
 
 @patch('src.efa_api.requests.get')
+def test_get_best_stop_name(mock_get):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        'stopFinder': {
+            'points': {
+                'point': [
+                    {'name': 'Bozen Hbf', 'quality': '800'},
+                    {'name': 'Bozen, Stazione', 'quality': '990'},
+                ]
+            }
+        }
+    }
+    mock_get.return_value = resp
+
+    name = efa_api._get_best_stop_name('Bozen')
+    assert name == 'Bozen, Stazione'
+
+
+@patch('src.efa_api.requests.get')
 def test_search_efa_calls_requests(mock_get):
-    mock_get.return_value.status_code = 200
-    mock_get.return_value.json.return_value = {'ok': True}
+    def side_effect(url, params=None, timeout=10):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        if url.endswith('XML_STOPFINDER_REQUEST'):
+            mock_resp.json.return_value = {
+                'stopFinder': {
+                    'points': {'point': {'name': params['name_sf'], 'quality': '999'}}
+                }
+            }
+        else:
+            mock_resp.json.return_value = {'ok': True}
+        return mock_resp
+
+    mock_get.side_effect = side_effect
+
     params = {'from_stop': 'Bozen', 'to_stop': 'Meran', 'time': '08:00'}
     result = efa_api.search_efa(params)
 
-    mock_get.assert_called_once()
-    url, kwargs = mock_get.call_args
-    assert url[0].endswith('/XML_TRIP_REQUEST2')
-    efa_params = kwargs['params']
+    assert mock_get.call_count == 3
+    trip_call = mock_get.call_args_list[-1]
+    assert trip_call[0][0].endswith('/XML_TRIP_REQUEST2')
+    efa_params = trip_call[1]['params']
     assert efa_params['name_origin'] == 'Bozen'
     assert efa_params['name_destination'] == 'Meran'
     assert efa_params['itdTime'] == '08:00'


### PR DESCRIPTION
## Summary
- search the stop names using `XML_STOPFINDER_REQUEST` and pick the best quality hit
- use these resolved stop names for the trip request
- add unit tests for stopfinder lookup and updated trip logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864ec768de483218331f7444a472168