### PR TITLE
Remove stray separator in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ For a deeper understanding of the Mentz‑EFA endpoints, see
 EFA_BASE_URL=https://efa.sta.bz.it/apb uvicorn src.main:app --reload
 ```
 
-=======
 
 ## Example request
 


### PR DESCRIPTION
## Summary
- remove leftover `=======` separator from the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864ec137b088321bbd3bd4f7d3a9e85