### PR TITLE
Server accessible beyond localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ by running the above command again.
 Start the API using `uvicorn` so that code changes are picked up automatically:
 
 ```bash
-uvicorn src.main:app --reload
+uvicorn src.main:app --host 0.0.0.0 --reload
 ```
 
 Running `python -m src.main` also starts the server but does not enable
@@ -46,7 +46,7 @@ For a deeper understanding of the Mentz‑EFA endpoints, see
 [docs/EFA_XML_API.md](docs/EFA_XML_API.md).
 
 ```bash
-EFA_BASE_URL=https://efa.sta.bz.it/apb uvicorn src.main:app --reload
+EFA_BASE_URL=https://efa.sta.bz.it/apb uvicorn src.main:app --host 0.0.0.0 --reload
 ```
 
 

--- a/install.sh
+++ b/install.sh
@@ -28,4 +28,4 @@ python -m spacy download de_core_news_sm || true
 
 echo "\nInstallation complete."
 echo "Activate the environment with 'source venv/bin/activate'."
-echo "Run the server using: uvicorn src.main:app --reload"
+echo "Run the server using: uvicorn src.main:app --host 0.0.0.0 --reload"


### PR DESCRIPTION
## Summary
- run Uvicorn on `0.0.0.0` in README instructions
- document the host change in `install.sh`

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6864f541dffc8321bcee9fe9a74ded74