### PR TITLE
Use stateless stop identifiers

### DIFF
--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -8,8 +8,9 @@ BASE_URL = os.environ.get("EFA_BASE_URL", "https://efa.sta.bz.it/apb")
 def _get_best_stop_name(query: str) -> str:
     """Lookup a stop using the StopFinder request and return the best match.
 
-    If the request fails or returns no usable result, the original query is
-    returned unchanged.
+    The function prefers the ``stateless`` identifier of the best suggestion
+    so that the result can be used directly in subsequent requests. If the
+    lookup fails, the original query is returned unchanged.
     """
     url = f"{BASE_URL}/XML_STOPFINDER_REQUEST"
     params = {
@@ -41,8 +42,11 @@ def _get_best_stop_name(query: str) -> str:
                 best_quality = quality
                 best = p
 
-        if best and best.get("name"):
-            return best["name"]
+        if best:
+            if best.get("stateless"):
+                return best["stateless"]
+            if best.get("name"):
+                return best["name"]
     except Exception:
         pass
 

--- a/tests/test_efa_api.py
+++ b/tests/test_efa_api.py
@@ -10,16 +10,20 @@ def test_get_best_stop_name(mock_get):
         'stopFinder': {
             'points': {
                 'point': [
-                    {'name': 'Bozen Hbf', 'quality': '800'},
-                    {'name': 'Bozen, Stazione', 'quality': '990'},
+                    {'name': 'Bozen Hbf', 'quality': '800', 'stateless': 's1'},
+                    {
+                        'name': 'Bozen, Stazione',
+                        'quality': '990',
+                        'stateless': 's2',
+                    },
                 ]
             }
         }
     }
     mock_get.return_value = resp
 
-    name = efa_api._get_best_stop_name('Bozen')
-    assert name == 'Bozen, Stazione'
+    best = efa_api._get_best_stop_name('Bozen')
+    assert best == 's2'
 
 
 @patch('src.efa_api.requests.get')
@@ -30,7 +34,13 @@ def test_search_efa_calls_requests(mock_get):
         if url.endswith('XML_STOPFINDER_REQUEST'):
             mock_resp.json.return_value = {
                 'stopFinder': {
-                    'points': {'point': {'name': params['name_sf'], 'quality': '999'}}
+                    'points': {
+                        'point': {
+                            'name': params['name_sf'],
+                            'quality': '999',
+                            'stateless': params['name_sf'] + '_SL',
+                        }
+                    }
                 }
             }
         else:
@@ -46,8 +56,8 @@ def test_search_efa_calls_requests(mock_get):
     trip_call = mock_get.call_args_list[-1]
     assert trip_call[0][0].endswith('/XML_TRIP_REQUEST2')
     efa_params = trip_call[1]['params']
-    assert efa_params['name_origin'] == 'Bozen'
-    assert efa_params['name_destination'] == 'Meran'
+    assert efa_params['name_origin'] == 'Bozen_SL'
+    assert efa_params['name_destination'] == 'Meran_SL'
     assert efa_params['itdTime'] == '08:00'
     assert result == {'ok': True}
 


### PR DESCRIPTION
## Summary
- prefer the stateless identifier when resolving stop names
- adapt `search_efa` tests for new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f6a1ccb08321bbbaac97369e805b