### PR TITLE
Add DM and StopFinder endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,25 @@ EFA_BASE_URL=https://efa.sta.bz.it/apb uvicorn src.main:app --host 0.0.0.0 --rel
 ```
 
 
-## Example request
+## Example requests
 
 After the server is running, you can query it with a POST request:
 
 ```bash
+# Trip request
 curl -X POST http://localhost:8000/search \
      -H 'Content-Type: application/json' \
      -d '{"text": "Wie komme ich von Bozen nach Meran um 14:30?"}'
+
+# Departure monitor
+curl -X POST http://localhost:8000/departures \
+     -H 'Content-Type: application/json' \
+     -d '{"stop": "Bozen", "limit": 5}'
+
+# Stop suggestions
+curl -X POST http://localhost:8000/stops \
+     -H 'Content-Type: application/json' \
+     -d '{"query": "Brixen"}'
 ```
 
 The response JSON mirrors the data returned by the underlying EFA service. Important fields include:
@@ -74,7 +85,14 @@ prints feedback messages while processing the query. Run it with Python's
 module syntax:
 
 ```bash
-python -m src.cli "Wie komme ich von Bozen nach Meran um 14:30?"
+# Trip request
+python -m src.cli search "Wie komme ich von Bozen nach Meran um 14:30?"
+
+# Departure monitor
+python -m src.cli departures "Bozen"
+
+# Stop suggestions
+python -m src.cli stops "Brixen"
 ```
 
 The script prints progress updates such as "Searching for stops..." and shows

--- a/src/cli.py
+++ b/src/cli.py
@@ -29,8 +29,38 @@ def run_search(query: str) -> None:
     print(response)
 
 
+def run_departures(stop: str) -> None:
+    print("Querying departures...")
+    try:
+        result = efa_api.dm_request(stop)
+    except Exception as exc:
+        print(f"Error during request: {exc}")
+        return
+    print(result)
+
+
+def run_stop_finder(query: str) -> None:
+    print("Searching stops...")
+    try:
+        result = efa_api.stop_finder(query)
+    except Exception as exc:
+        print(f"Error during request: {exc}")
+        return
+    print(result)
+
+
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        print("Usage: python -m src.cli 'your query'")
+    if len(sys.argv) < 3:
+        print("Usage: python -m src.cli [search|departures|stops] 'query'")
+        sys.exit(1)
+
+    command = sys.argv[1]
+    argument = " ".join(sys.argv[2:])
+    if command == "search":
+        run_search(argument)
+    elif command == "departures":
+        run_departures(argument)
+    elif command == "stops":
+        run_stop_finder(argument)
     else:
-        run_search(" ".join(sys.argv[1:]))
+        print(f"Unknown command: {command}")

--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -91,3 +91,33 @@ def search_efa(params: Dict[str, Any]) -> Dict[str, Any]:
     except ValueError:
         return {"text": response.text}
 
+
+def dm_request(stop_name: str, limit: int = 10) -> Dict[str, Any]:
+    """Query the departure monitor (DM) endpoint for a specific stop."""
+    url = f"{BASE_URL}/XML_DM_REQUEST"
+    stop_name = _get_best_stop_name(stop_name)
+    params = {
+        "language": "de",
+        "type_dm": "stop",
+        "name_dm": stop_name,
+        "mode": "direct",
+        "limit": limit,
+        "outputFormat": "JSON",
+    }
+
+    response = requests.get(url, params=params, timeout=10)
+    response.raise_for_status()
+    try:
+        return response.json()
+    except ValueError:
+        return {"text": response.text}
+
+
+def stop_finder(query: str) -> Dict[str, Any]:
+    """Return stop suggestions for the given search string."""
+    url = f"{BASE_URL}/XML_STOPFINDER_REQUEST"
+    params = {"odvSugMacro": 1, "name_sf": query, "outputFormat": "JSON"}
+    response = requests.get(url, params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()
+

--- a/src/main.py
+++ b/src/main.py
@@ -7,12 +7,36 @@ app = FastAPI()
 class SearchRequest(BaseModel):
     text: str
 
+class DMRequest(BaseModel):
+    stop: str
+    limit: int = 10
+
+
+class StopFinderRequest(BaseModel):
+    query: str
+
 @app.post("/search")
 def search(req: SearchRequest):
     params = nlp_parser.parse_query(req.text)
     if not params:
         raise HTTPException(status_code=400, detail="No parameters extracted")
     return efa_api.search_efa(params)
+
+
+@app.post("/departures")
+def departures(req: DMRequest):
+    """Return upcoming departures for the given stop."""
+    if not req.stop:
+        raise HTTPException(status_code=400, detail="Missing stop name")
+    return efa_api.dm_request(req.stop, req.limit)
+
+
+@app.post("/stops")
+def stops(req: StopFinderRequest):
+    """Return stop suggestions for the given query."""
+    if not req.query:
+        raise HTTPException(status_code=400, detail="Missing query")
+    return efa_api.stop_finder(req.query)
 
 # Run via ``python -m src.main`` for debugging without auto-reload.
 if __name__ == "__main__" and __package__:

--- a/tests/test_efa_api.py
+++ b/tests/test_efa_api.py
@@ -51,3 +51,31 @@ def test_search_efa_calls_requests(mock_get):
     assert efa_params['itdTime'] == '08:00'
     assert result == {'ok': True}
 
+
+@patch('src.efa_api._get_best_stop_name', return_value='Bozen')
+@patch('src.efa_api.requests.get')
+def test_dm_request_calls_requests(mock_get, mock_best):
+    mock_get.return_value = MagicMock(status_code=200, json=lambda: {'ok': True})
+
+    result = efa_api.dm_request('Bozen', limit=5)
+
+    mock_get.assert_called_once()
+    args, kwargs = mock_get.call_args
+    assert args[0].endswith('/XML_DM_REQUEST')
+    assert kwargs['params']['name_dm'] == 'Bozen'
+    assert kwargs['params']['limit'] == 5
+    assert result == {'ok': True}
+
+
+@patch('src.efa_api.requests.get')
+def test_stop_finder_returns_json(mock_get):
+    mock_get.return_value = MagicMock(status_code=200, json=lambda: {'stops': []})
+
+    result = efa_api.stop_finder('Bruneck')
+
+    mock_get.assert_called_once()
+    args, kwargs = mock_get.call_args
+    assert args[0].endswith('/XML_STOPFINDER_REQUEST')
+    assert kwargs['params']['name_sf'] == 'Bruneck'
+    assert result == {'stops': []}
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,3 +15,25 @@ def test_search_endpoint(mock_parse_query, mock_search_efa):
     assert response.json() == expected_result
     mock_parse_query.assert_called_once_with('Wie komme ich von Bozen nach Meran?')
     mock_search_efa.assert_called_once_with({'from_stop': 'Bozen', 'to_stop': 'Meran'})
+
+
+@patch('src.main.efa_api.dm_request')
+def test_departures_endpoint(mock_dm_request):
+    expected = {'dm': 'ok'}
+    mock_dm_request.return_value = expected
+    client = TestClient(app)
+    response = client.post('/departures', json={'stop': 'Bozen', 'limit': 5})
+    assert response.status_code == 200
+    assert response.json() == expected
+    mock_dm_request.assert_called_once_with('Bozen', 5)
+
+
+@patch('src.main.efa_api.stop_finder')
+def test_stops_endpoint(mock_stop_finder):
+    expected = {'stops': []}
+    mock_stop_finder.return_value = expected
+    client = TestClient(app)
+    response = client.post('/stops', json={'query': 'Brixen'})
+    assert response.status_code == 200
+    assert response.json() == expected
+    mock_stop_finder.assert_called_once_with('Brixen')


### PR DESCRIPTION
## Summary
- extend Mentz-EFA client with DM and StopFinder helpers
- expose `/departures` and `/stops` endpoints in the FastAPI app
- enhance CLI to support new commands
- document new endpoints and CLI usage in README
- add tests for new functions and endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f78f1fb08321b208088cc81e8f75