### PR TITLE
Add user feedback messages for departure queries

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -30,12 +30,16 @@ def run_search(query: str) -> None:
 
 
 def run_departures(stop: str) -> None:
-    print("Querying departures...")
+    """Query the departure monitor and show progress messages."""
+    print(f"Haltestelle '{stop}' wird ermittelt...")
     try:
         result = efa_api.dm_request(stop)
     except Exception as exc:
-        print(f"Error during request: {exc}")
+        print(f"Fehler bei der Abfrage: {exc}")
         return
+
+    print("Suche wird gestartet...")
+    print("Ergebnisse gefunden.")
     print(result)
 
 


### PR DESCRIPTION
## Summary
- show German progress messages when querying departures

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864fb6c31f883218f569d6e0783d80c