### PR TITLE
Add logging and debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ python -m src.cli stops "Brixen"
 The script prints progress updates such as "Searching for stops..." and shows
 the raw API response when finished.
 
+### Debug mode
+
+Enable verbose logging for both the CLI and the server by setting the
+`SM_DEBUG` environment variable or passing `--debug` to the CLI:
+
+```bash
+SM_DEBUG=1 python -m src.cli search "Bozen nach Meran"
+```
+
 
 ## Testing
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,70 +1,77 @@
 import sys
+import argparse
+import logging
+
 from . import nlp_parser, efa_api
+from .logging_utils import setup_logging
+
+logger = logging.getLogger(__name__)
 
 
 def run_search(query: str) -> None:
     """Run a search for the given natural language query with progress output."""
-    print("Searching for stops...")
+    logger.info("Searching for stops...")
     params = nlp_parser.parse_query(query)
 
     if not params:
-        print("No parameters extracted from the query.")
+        logger.warning("No parameters extracted from the query.")
         return
 
-    print("Determining results...")
+    logger.info("Determining results...")
     try:
         response = efa_api.search_efa(params)
     except Exception as exc:
-        print(f"Error during search: {exc}")
+        logger.error("Error during search: %s", exc)
         return
 
-    print("Interpreting results...")
+    logger.info("Interpreting results...")
     if isinstance(response, dict) and "trips" in response:
         trips = response.get("trips") or []
-        print(f"Found {len(trips)} trips.")
+        logger.info("Found %d trips.", len(trips))
     else:
-        print("No trip data found.")
+        logger.info("No trip data found.")
 
-    print("Returning search results...")
+    logger.info("Returning search results...")
     print(response)
 
 
 def run_departures(stop: str) -> None:
     """Query the departure monitor and show progress messages."""
-    print(f"Haltestelle '{stop}' wird ermittelt...")
+    logger.info("Haltestelle '%s' wird ermittelt...", stop)
     try:
         result = efa_api.dm_request(stop)
     except Exception as exc:
-        print(f"Fehler bei der Abfrage: {exc}")
+        logger.error("Fehler bei der Abfrage: %s", exc)
         return
 
-    print("Suche wird gestartet...")
-    print("Ergebnisse gefunden.")
+    logger.info("Suche wird gestartet...")
+    logger.info("Ergebnisse gefunden.")
     print(result)
 
 
 def run_stop_finder(query: str) -> None:
-    print("Searching stops...")
+    logger.info("Searching stops...")
     try:
         result = efa_api.stop_finder(query)
     except Exception as exc:
-        print(f"Error during request: {exc}")
+        logger.error("Error during request: %s", exc)
         return
     print(result)
 
 
 if __name__ == "__main__":
-    if len(sys.argv) < 3:
-        print("Usage: python -m src.cli [search|departures|stops] 'query'")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(description="suedtirolmobilAI CLI")
+    parser.add_argument("command", choices=["search", "departures", "stops"], help="Command to execute")
+    parser.add_argument("text", nargs="+", help="Query text or stop name")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
 
-    command = sys.argv[1]
-    argument = " ".join(sys.argv[2:])
-    if command == "search":
+    args = parser.parse_args()
+    setup_logging(args.debug)
+
+    argument = " ".join(args.text)
+    if args.command == "search":
         run_search(argument)
-    elif command == "departures":
+    elif args.command == "departures":
         run_departures(argument)
-    elif command == "stops":
+    elif args.command == "stops":
         run_stop_finder(argument)
-    else:
-        print(f"Unknown command: {command}")

--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -1,6 +1,12 @@
 import os
 from typing import Dict, Any, List, Optional
+import logging
 import requests
+
+from .logging_utils import setup_logging
+
+logger = logging.getLogger(__name__)
+setup_logging()
 
 BASE_URL = os.environ.get("EFA_BASE_URL", "https://efa.sta.bz.it/apb")
 
@@ -19,9 +25,11 @@ def get_stop_code(query: str) -> str:
         "outputFormat": "JSON",
     }
 
+    logger.debug("Requesting stop code for '%s'", query)
     try:
         response = requests.get(url, params=params, timeout=10)
         response.raise_for_status()
+        logger.debug("StopFinder response status: %s", response.status_code)
         data = response.json()
         points: List[Dict[str, Any]] = (
             data.get("stopFinder", {})
@@ -42,13 +50,18 @@ def get_stop_code(query: str) -> str:
                 best_quality = quality
                 best = p
 
+        logger.debug("Stop suggestions: %s", points)
+        logger.debug("Best match: %s", best)
+
         if best:
             if best.get("stateless"):
+                logger.debug("Using stateless code: %s", best["stateless"])
                 return best["stateless"]
             if best.get("name"):
+                logger.debug("Using stop name: %s", best["name"])
                 return best["name"]
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("Stop code lookup failed for '%s': %s", query, exc)
 
     return query
 
@@ -67,6 +80,8 @@ def search_efa(params: Dict[str, Any]) -> Dict[str, Any]:
         JSON response from the API.
     """
     url = f"{BASE_URL}/XML_TRIP_REQUEST2"
+
+    logger.info("Searching trip: %s", params)
 
     from_stop = params.get("from_stop")
     if from_stop:
@@ -87,11 +102,15 @@ def search_efa(params: Dict[str, Any]) -> Dict[str, Any]:
     time = params.get("time")
     if time:
         efa_params["itdTime"] = time
+    logger.debug("Trip request params: %s", efa_params)
 
     response = requests.get(url, params=efa_params, timeout=10)
     response.raise_for_status()
+    logger.debug("Trip request status: %s", response.status_code)
     try:
-        return response.json()
+        data = response.json()
+        logger.debug("Trip response payload: %s", data)
+        return data
     except ValueError:
         return {"text": response.text}
 
@@ -99,6 +118,7 @@ def search_efa(params: Dict[str, Any]) -> Dict[str, Any]:
 def dm_request(stop_name: str, limit: int = 10) -> Dict[str, Any]:
     """Query the departure monitor (DM) endpoint for a specific stop."""
     url = f"{BASE_URL}/XML_DM_REQUEST"
+    logger.info("Requesting departures for '%s'", stop_name)
     stop_name = get_stop_code(stop_name)
     params = {
         "language": "de",
@@ -109,10 +129,14 @@ def dm_request(stop_name: str, limit: int = 10) -> Dict[str, Any]:
         "outputFormat": "JSON",
     }
 
+    logger.debug("DM request params: %s", params)
     response = requests.get(url, params=params, timeout=10)
     response.raise_for_status()
+    logger.debug("DM request status: %s", response.status_code)
     try:
-        return response.json()
+        data = response.json()
+        logger.debug("DM response payload: %s", data)
+        return data
     except ValueError:
         return {"text": response.text}
 
@@ -121,7 +145,11 @@ def stop_finder(query: str) -> Dict[str, Any]:
     """Return stop suggestions for the given search string."""
     url = f"{BASE_URL}/XML_STOPFINDER_REQUEST"
     params = {"odvSugMacro": 1, "name_sf": query, "outputFormat": "JSON"}
+    logger.info("Stop finder for query '%s'", query)
+    logger.debug("StopFinder params: %s", params)
     response = requests.get(url, params=params, timeout=10)
     response.raise_for_status()
-    return response.json()
+    data = response.json()
+    logger.debug("StopFinder response: %s", data)
+    return data
 

--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -1,0 +1,14 @@
+import logging
+import os
+
+
+def setup_logging(debug: bool | None = None) -> None:
+    """Configure basic logging for the application."""
+    if debug is None:
+        debug = os.environ.get("SM_DEBUG") in {"1", "true", "True"}
+    level = logging.DEBUG if debug else logging.INFO
+    # Only configure root logger if it hasn't been configured yet
+    if not logging.getLogger().handlers:
+        logging.basicConfig(level=level, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+    else:
+        logging.getLogger().setLevel(level)

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,13 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
+import logging
+import os
+
 from . import nlp_parser, efa_api
+from .logging_utils import setup_logging
+
+setup_logging(os.environ.get("SM_DEBUG") in {"1", "true", "True"})
+logger = logging.getLogger(__name__)
 
 app = FastAPI()
 
@@ -17,26 +24,35 @@ class StopFinderRequest(BaseModel):
 
 @app.post("/search")
 def search(req: SearchRequest):
+    logger.info("/search text='%s'", req.text)
     params = nlp_parser.parse_query(req.text)
     if not params:
         raise HTTPException(status_code=400, detail="No parameters extracted")
-    return efa_api.search_efa(params)
+    result = efa_api.search_efa(params)
+    logger.debug("/search result: %s", result)
+    return result
 
 
 @app.post("/departures")
 def departures(req: DMRequest):
     """Return upcoming departures for the given stop."""
+    logger.info("/departures stop='%s' limit=%s", req.stop, req.limit)
     if not req.stop:
         raise HTTPException(status_code=400, detail="Missing stop name")
-    return efa_api.dm_request(req.stop, req.limit)
+    result = efa_api.dm_request(req.stop, req.limit)
+    logger.debug("/departures result: %s", result)
+    return result
 
 
 @app.post("/stops")
 def stops(req: StopFinderRequest):
     """Return stop suggestions for the given query."""
+    logger.info("/stops query='%s'", req.query)
     if not req.query:
         raise HTTPException(status_code=400, detail="Missing query")
-    return efa_api.stop_finder(req.query)
+    result = efa_api.stop_finder(req.query)
+    logger.debug("/stops result: %s", result)
+    return result
 
 # Run via ``python -m src.main`` for debugging without auto-reload.
 if __name__ == "__main__" and __package__:

--- a/src/nlp_parser.py
+++ b/src/nlp_parser.py
@@ -1,6 +1,12 @@
 from typing import Dict, Optional
 import re
+import logging
 import spacy
+
+from .logging_utils import setup_logging
+
+logger = logging.getLogger(__name__)
+setup_logging()
 
 _nlp = None
 
@@ -16,6 +22,7 @@ def _get_nlp():
 def parse_query(text: str) -> Dict[str, Optional[str]]:
     """Extract stops and time from a natural language query."""
     nlp = _get_nlp()
+    logger.debug("Parsing text: %s", text)
     doc = nlp(text)
     stops = [token.text for token in doc if token.pos_ == "PROPN"]
     if not stops:
@@ -37,5 +44,6 @@ def parse_query(text: str) -> Dict[str, Optional[str]]:
         result["to_stop"] = stops[1]
     if time:
         result["time"] = time
+    logger.debug("Parsed parameters: %s", result)
     return result
 


### PR DESCRIPTION
## Summary
- add `logging_utils` helper
- log API requests and CLI progress
- expose debug flag via `--debug` and `SM_DEBUG`
- document debug mode in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864fdca84fc8321bea0e5d89530cec5