### PR TITLE
Add locationServerActive parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ For a deeper understanding of the Mentz‑EFA endpoints, see
 EFA_BASE_URL=https://efa.sta.bz.it/apb uvicorn src.main:app --host 0.0.0.0 --reload
 ```
 
+All requests automatically enable the EFA location server via
+`locationServerActive=1`. Trip and departure monitor queries also send
+`odvMacro=true`.
+
 
 ## Example requests
 

--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -23,6 +23,7 @@ def get_stop_code(query: str) -> str:
         "odvSugMacro": 1,
         "name_sf": query,
         "outputFormat": "JSON",
+        "locationServerActive": 1,
     }
 
     logger.debug("Requesting stop code for '%s'", query)
@@ -97,6 +98,8 @@ def search_efa(params: Dict[str, Any]) -> Dict[str, Any]:
         "type_destination": "any",
         "outputFormat": "JSON",
         "calcNumberOfTrips": 1,
+        "locationServerActive": 1,
+        "odvMacro": "true",
     }
 
     time = params.get("time")
@@ -127,6 +130,8 @@ def dm_request(stop_name: str, limit: int = 10) -> Dict[str, Any]:
         "mode": "direct",
         "limit": limit,
         "outputFormat": "JSON",
+        "locationServerActive": 1,
+        "odvMacro": "true",
     }
 
     logger.debug("DM request params: %s", params)

--- a/tests/test_efa_api.py
+++ b/tests/test_efa_api.py
@@ -24,6 +24,9 @@ def test_get_stop_code(mock_get):
 
     code = efa_api.get_stop_code('Bozen')
     assert code == 's2'
+    mock_get.assert_called_once()
+    args, kwargs = mock_get.call_args
+    assert kwargs['params']['locationServerActive'] == 1
 
 
 @patch('src.efa_api.requests.get')
@@ -59,6 +62,8 @@ def test_search_efa_calls_requests(mock_get):
     assert efa_params['name_origin'] == 'Bozen_SL'
     assert efa_params['name_destination'] == 'Meran_SL'
     assert efa_params['itdTime'] == '08:00'
+    assert efa_params['locationServerActive'] == 1
+    assert efa_params['odvMacro'] == 'true'
     assert result == {'ok': True}
 
 
@@ -74,6 +79,8 @@ def test_dm_request_calls_requests(mock_get, mock_best):
     assert args[0].endswith('/XML_DM_REQUEST')
     assert kwargs['params']['name_dm'] == 'Bozen'
     assert kwargs['params']['limit'] == 5
+    assert kwargs['params']['locationServerActive'] == 1
+    assert kwargs['params']['odvMacro'] == 'true'
     assert result == {'ok': True}
 
 


### PR DESCRIPTION
## Summary
- add `locationServerActive=1` to EFA API helper functions
- include `odvMacro=true` where required
- update tests for the new parameters
- document default EFA query parameters

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68650103978c83219921d8d84bdf7325