### PR TITLE
Rename stop finder helper

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -52,7 +52,7 @@ def run_departures(stop: str) -> None:
 def run_stop_finder(query: str) -> None:
     logger.info("Searching stops...")
     try:
-        result = efa_api.stop_finder(query)
+        result = efa_api.stopfinder_request(query)
     except Exception as exc:
         logger.error("Error during request: %s", exc)
         return

--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -146,7 +146,7 @@ def dm_request(stop_name: str, limit: int = 10) -> Dict[str, Any]:
         return {"text": response.text}
 
 
-def stop_finder(query: str) -> Dict[str, Any]:
+def stopfinder_request(query: str) -> Dict[str, Any]:
     """Return stop suggestions for the given search string."""
     url = f"{BASE_URL}/XML_STOPFINDER_REQUEST"
     params = {"odvSugMacro": 1, "name_sf": query, "outputFormat": "JSON"}
@@ -157,4 +157,7 @@ def stop_finder(query: str) -> Dict[str, Any]:
     data = response.json()
     logger.debug("StopFinder response: %s", data)
     return data
+
+# Backwards compatibility
+stop_finder = stopfinder_request
 

--- a/src/main.py
+++ b/src/main.py
@@ -50,7 +50,7 @@ def stops(req: StopFinderRequest):
     logger.info("/stops query='%s'", req.query)
     if not req.query:
         raise HTTPException(status_code=400, detail="Missing query")
-    result = efa_api.stop_finder(req.query)
+    result = efa_api.stopfinder_request(req.query)
     logger.debug("/stops result: %s", result)
     return result
 

--- a/tests/test_efa_api.py
+++ b/tests/test_efa_api.py
@@ -85,10 +85,10 @@ def test_dm_request_calls_requests(mock_get, mock_best):
 
 
 @patch('src.efa_api.requests.get')
-def test_stop_finder_returns_json(mock_get):
+def test_stopfinder_request_returns_json(mock_get):
     mock_get.return_value = MagicMock(status_code=200, json=lambda: {'stops': []})
 
-    result = efa_api.stop_finder('Bruneck')
+    result = efa_api.stopfinder_request('Bruneck')
 
     mock_get.assert_called_once()
     args, kwargs = mock_get.call_args

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -28,12 +28,12 @@ def test_departures_endpoint(mock_dm_request):
     mock_dm_request.assert_called_once_with('Bozen', 5)
 
 
-@patch('src.main.efa_api.stop_finder')
-def test_stops_endpoint(mock_stop_finder):
+@patch('src.main.efa_api.stopfinder_request')
+def test_stops_endpoint(mock_stopfinder_request):
     expected = {'stops': []}
-    mock_stop_finder.return_value = expected
+    mock_stopfinder_request.return_value = expected
     client = TestClient(app)
     response = client.post('/stops', json={'query': 'Brixen'})
     assert response.status_code == 200
     assert response.json() == expected
-    mock_stop_finder.assert_called_once_with('Brixen')
+    mock_stopfinder_request.assert_called_once_with('Brixen')


### PR DESCRIPTION
## Summary
- rename `stop_finder` to `stopfinder_request`
- update CLI, API and tests to use the new helper name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686510065ea483218047c8a8da4baf8e