### PR TITLE
Enable optional text summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,18 @@ All requests automatically enable the EFA location server via
 
 ## Example requests
 
-After the server is running, you can query it with a POST request:
+After the server is running, you can query it with a POST request. By default
+the API returns JSON. Append `?format=text` to any endpoint for a short
+human‑readable summary:
 
 ```bash
-# Trip request
+# Trip request (JSON)
 curl -X POST http://localhost:8000/search \
+     -H 'Content-Type: application/json' \
+     -d '{"text": "Wie komme ich von Bozen nach Meran um 14:30?"}'
+
+# Trip request (plain text)
+curl -X POST 'http://localhost:8000/search?format=text' \
      -H 'Content-Type: application/json' \
      -d '{"text": "Wie komme ich von Bozen nach Meran um 14:30?"}'
 
@@ -69,8 +76,18 @@ curl -X POST http://localhost:8000/departures \
      -H 'Content-Type: application/json' \
      -d '{"stop": "Bozen", "limit": 5}'
 
+# Departure monitor (plain text)
+curl -X POST 'http://localhost:8000/departures?format=text' \
+     -H 'Content-Type: application/json' \
+     -d '{"stop": "Bozen", "limit": 5}'
+
 # Stop suggestions
 curl -X POST http://localhost:8000/stops \
+     -H 'Content-Type: application/json' \
+     -d '{"query": "Brixen"}'
+
+# Stop suggestions (plain text)
+curl -X POST 'http://localhost:8000/stops?format=text' \
      -H 'Content-Type: application/json' \
      -d '{"query": "Brixen"}'
 ```

--- a/src/cli.py
+++ b/src/cli.py
@@ -4,108 +4,13 @@ import logging
 
 from . import nlp_parser, efa_api
 from .logging_utils import setup_logging
+from .summaries import (
+    format_search_result,
+    format_departures_result,
+    format_stops_result,
+)
 
 logger = logging.getLogger(__name__)
-
-
-def _plural(word: str, count: int) -> str:
-    """Return pluralized word depending on count."""
-    return word if count == 1 else f"{word}s"
-
-
-def _format_search_result(result: dict) -> str:
-    """Return a readable summary of a trip search result."""
-    if not isinstance(result, dict):
-        return str(result)
-
-    from_stop = (
-        result.get("from_stop")
-        or result.get("origin", {}).get("name")
-        or ""
-    )
-    to_stop = (
-        result.get("to_stop")
-        or result.get("destination", {}).get("name")
-        or ""
-    )
-
-    trips = result.get("trips")
-    count = 0
-    if isinstance(trips, list):
-        count = len(trips)
-    elif isinstance(trips, dict):
-        trip_data = trips.get("trip")
-        if isinstance(trip_data, list):
-            count = len(trip_data)
-        elif trip_data:
-            count = 1
-        else:
-            count = len(trips)
-
-    if not from_stop and not to_stop:
-        return f"{count} {_plural('trip', count)} found."
-    if not from_stop:
-        return f"{count} {_plural('trip', count)} to {to_stop}."
-    if not to_stop:
-        return f"{count} {_plural('trip', count)} from {from_stop}."
-    return f"{count} {_plural('trip', count)} from {from_stop} to {to_stop}."
-
-
-def _format_departures_result(result: dict) -> str:
-    """Return a readable summary of departures."""
-    if not isinstance(result, dict):
-        return str(result)
-
-    stop_name = (
-        result.get("stop_name")
-        or result.get("stopName")
-        or result.get("stop", {}).get("name")
-        or result.get("name")
-        or ""
-    )
-
-    departures = (
-        result.get("departures")
-        or result.get("departureList")
-        or result.get("stopEvents")
-    )
-    count = 0
-    if isinstance(departures, list):
-        count = len(departures)
-    elif departures:
-        count = 1
-
-    suffix = f" for '{stop_name}'" if stop_name else ""
-    return f"{count} {_plural('departure', count)}{suffix}."
-
-
-def _format_stops_result(result: dict) -> str:
-    """Return a readable summary of stop suggestions."""
-    if not isinstance(result, dict):
-        return str(result)
-
-    points = (
-        result.get("stopFinder", {}).get("points", {}).get("point")
-        or result.get("stops")
-    )
-    names = []
-    count = 0
-    if isinstance(points, list):
-        count = len(points)
-        for p in points:
-            if isinstance(p, dict) and p.get("name"):
-                names.append(p["name"])
-    elif isinstance(points, dict):
-        count = 1
-        if points.get("name"):
-            names.append(points["name"])
-
-    if names:
-        shown = ", ".join(names[:3])
-        if len(names) > 3:
-            shown += " ..."
-        return f"{count} {_plural('stop', count)} found: {shown}"
-    return f"{count} {_plural('stop', count)} found."
 
 
 def run_search(query: str) -> None:
@@ -132,7 +37,7 @@ def run_search(query: str) -> None:
         logger.info("No trip data found.")
 
     logger.info("Returning search results...")
-    print(_format_search_result(response))
+    print(format_search_result(response))
 
 
 def run_departures(stop: str) -> None:
@@ -146,7 +51,7 @@ def run_departures(stop: str) -> None:
 
     logger.info("Suche wird gestartet...")
     logger.info("Ergebnisse gefunden.")
-    print(_format_departures_result(result))
+    print(format_departures_result(result))
 
 
 def run_stop_finder(query: str) -> None:
@@ -156,7 +61,7 @@ def run_stop_finder(query: str) -> None:
     except Exception as exc:
         logger.error("Error during request: %s", exc)
         return
-    print(_format_stops_result(result))
+    print(format_stops_result(result))
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,15 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 import logging
 import os
 
 from . import nlp_parser, efa_api
+from .summaries import (
+    format_search_result,
+    format_departures_result,
+    format_stops_result,
+)
 from .logging_utils import setup_logging
 
 setup_logging(os.environ.get("SM_DEBUG") in {"1", "true", "True"})
@@ -23,35 +29,41 @@ class StopFinderRequest(BaseModel):
     query: str
 
 @app.post("/search")
-def search(req: SearchRequest):
+def search(req: SearchRequest, format: str = "json"):
     logger.info("/search text='%s'", req.text)
     params = nlp_parser.parse_query(req.text)
     if not params:
         raise HTTPException(status_code=400, detail="No parameters extracted")
     result = efa_api.search_efa(params)
     logger.debug("/search result: %s", result)
+    if format == "text":
+        return PlainTextResponse(format_search_result(result))
     return result
 
 
 @app.post("/departures")
-def departures(req: DMRequest):
+def departures(req: DMRequest, format: str = "json"):
     """Return upcoming departures for the given stop."""
     logger.info("/departures stop='%s' limit=%s", req.stop, req.limit)
     if not req.stop:
         raise HTTPException(status_code=400, detail="Missing stop name")
     result = efa_api.dm_request(req.stop, req.limit)
     logger.debug("/departures result: %s", result)
+    if format == "text":
+        return PlainTextResponse(format_departures_result(result))
     return result
 
 
 @app.post("/stops")
-def stops(req: StopFinderRequest):
+def stops(req: StopFinderRequest, format: str = "json"):
     """Return stop suggestions for the given query."""
     logger.info("/stops query='%s'", req.query)
     if not req.query:
         raise HTTPException(status_code=400, detail="Missing query")
     result = efa_api.stopfinder_request(req.query)
     logger.debug("/stops result: %s", result)
+    if format == "text":
+        return PlainTextResponse(format_stops_result(result))
     return result
 
 # Run via ``python -m src.main`` for debugging without auto-reload.

--- a/src/summaries.py
+++ b/src/summaries.py
@@ -1,0 +1,103 @@
+"""Utility functions to create human readable summaries."""
+
+from typing import Any, Dict, List
+
+
+def _plural(word: str, count: int) -> str:
+    """Return pluralized word depending on count."""
+    return word if count == 1 else f"{word}s"
+
+
+def format_search_result(result: Dict[str, Any]) -> str:
+    """Return a readable summary of a trip search result."""
+    if not isinstance(result, dict):
+        return str(result)
+
+    from_stop = (
+        result.get("from_stop")
+        or result.get("origin", {}).get("name")
+        or ""
+    )
+    to_stop = (
+        result.get("to_stop")
+        or result.get("destination", {}).get("name")
+        or ""
+    )
+
+    trips = result.get("trips")
+    count = 0
+    if isinstance(trips, list):
+        count = len(trips)
+    elif isinstance(trips, dict):
+        trip_data = trips.get("trip")
+        if isinstance(trip_data, list):
+            count = len(trip_data)
+        elif trip_data:
+            count = 1
+        else:
+            count = len(trips)
+
+    if not from_stop and not to_stop:
+        return f"{count} {_plural('trip', count)} found."
+    if not from_stop:
+        return f"{count} {_plural('trip', count)} to {to_stop}."
+    if not to_stop:
+        return f"{count} {_plural('trip', count)} from {from_stop}."
+    return f"{count} {_plural('trip', count)} from {from_stop} to {to_stop}."
+
+
+def format_departures_result(result: Dict[str, Any]) -> str:
+    """Return a readable summary of departures."""
+    if not isinstance(result, dict):
+        return str(result)
+
+    stop_name = (
+        result.get("stop_name")
+        or result.get("stopName")
+        or result.get("stop", {}).get("name")
+        or result.get("name")
+        or ""
+    )
+
+    departures = (
+        result.get("departures")
+        or result.get("departureList")
+        or result.get("stopEvents")
+    )
+    count = 0
+    if isinstance(departures, list):
+        count = len(departures)
+    elif departures:
+        count = 1
+
+    suffix = f" for '{stop_name}'" if stop_name else ""
+    return f"{count} {_plural('departure', count)}{suffix}."
+
+
+def format_stops_result(result: Dict[str, Any]) -> str:
+    """Return a readable summary of stop suggestions."""
+    if not isinstance(result, dict):
+        return str(result)
+
+    points = (
+        result.get("stopFinder", {}).get("points", {}).get("point")
+        or result.get("stops")
+    )
+    names: List[str] = []
+    count = 0
+    if isinstance(points, list):
+        count = len(points)
+        for p in points:
+            if isinstance(p, dict) and p.get("name"):
+                names.append(p["name"])
+    elif isinstance(points, dict):
+        count = 1
+        if points.get("name"):
+            names.append(points["name"])
+
+    if names:
+        shown = ", ".join(names[:3])
+        if len(names) > 3:
+            shown += " ..."
+        return f"{count} {_plural('stop', count)} found: {shown}"
+    return f"{count} {_plural('stop', count)} found."

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,6 +17,19 @@ def test_search_endpoint(mock_parse_query, mock_search_efa):
     mock_search_efa.assert_called_once_with({'from_stop': 'Bozen', 'to_stop': 'Meran'})
 
 
+@patch('src.main.format_search_result', return_value='summary')
+@patch('src.main.efa_api.search_efa')
+@patch('src.main.nlp_parser.parse_query')
+def test_search_endpoint_text(mock_parse_query, mock_search_efa, mock_format):
+    mock_parse_query.return_value = {'from_stop': 'A', 'to_stop': 'B'}
+    mock_search_efa.return_value = {'dummy': True}
+    client = TestClient(app)
+    response = client.post('/search?format=text', json={'text': 'foo'})
+    assert response.status_code == 200
+    assert response.text == 'summary'
+    mock_format.assert_called_once()
+
+
 @patch('src.main.efa_api.dm_request')
 def test_departures_endpoint(mock_dm_request):
     expected = {'dm': 'ok'}
@@ -28,6 +41,17 @@ def test_departures_endpoint(mock_dm_request):
     mock_dm_request.assert_called_once_with('Bozen', 5)
 
 
+@patch('src.main.format_departures_result', return_value='dep')
+@patch('src.main.efa_api.dm_request')
+def test_departures_endpoint_text(mock_dm_request, mock_format):
+    mock_dm_request.return_value = {'ok': True}
+    client = TestClient(app)
+    response = client.post('/departures?format=text', json={'stop': 'B', 'limit': 1})
+    assert response.status_code == 200
+    assert response.text == 'dep'
+    mock_format.assert_called_once_with({'ok': True})
+
+
 @patch('src.main.efa_api.stopfinder_request')
 def test_stops_endpoint(mock_stopfinder_request):
     expected = {'stops': []}
@@ -37,3 +61,14 @@ def test_stops_endpoint(mock_stopfinder_request):
     assert response.status_code == 200
     assert response.json() == expected
     mock_stopfinder_request.assert_called_once_with('Brixen')
+
+
+@patch('src.main.format_stops_result', return_value='stops')
+@patch('src.main.efa_api.stopfinder_request')
+def test_stops_endpoint_text(mock_stopfinder_request, mock_format):
+    mock_stopfinder_request.return_value = {'foo': 'bar'}
+    client = TestClient(app)
+    response = client.post('/stops?format=text', json={'query': 'xyz'})
+    assert response.status_code == 200
+    assert response.text == 'stops'
+    mock_format.assert_called_once_with({'foo': 'bar'})


### PR DESCRIPTION
## Summary
- support plain text summaries via `?format=text`
- share summary formatting in new module
- update CLI to use shared summaries
- document text output option in README
- add tests for text responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686515d6cf3c832183edc55b201aa4c3