### PR TITLE
Fix stopfinder points None handling

### DIFF
--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -34,8 +34,7 @@ def get_stop_code(query: str) -> str:
         data = response.json()
         stopfinder = data.get("stopFinder") or {}
         points: List[Dict[str, Any]] = (
-            stopfinder
-            .get("points", {})
+            (stopfinder.get("points") or {})
             .get("point", [])
         )
         if isinstance(points, dict):

--- a/tests/test_efa_api.py
+++ b/tests/test_efa_api.py
@@ -45,6 +45,18 @@ def test_get_stop_code_handles_null_stopfinder(mock_get):
 
 
 @patch('src.efa_api.requests.get')
+def test_get_stop_code_handles_null_points(mock_get):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {'stopFinder': {'points': None}}
+    mock_get.return_value = resp
+
+    code = efa_api.get_stop_code('Bar')
+    assert code == 'Bar'
+    mock_get.assert_called_once()
+
+
+@patch('src.efa_api.requests.get')
 def test_search_efa_calls_requests(mock_get):
     def side_effect(url, params=None, timeout=10):
         mock_resp = MagicMock()


### PR DESCRIPTION
## Summary
- guard against `stopFinder['points']` being `None`
- add regression test for the None case
- pin httpx to 0.24.1 in tests to satisfy FastAPI requirements

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q httpx==0.24.1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651adb95a8832186f31d8ee99dd3da