### PR TITLE
Add location server to StopFinder requests

### DIFF
--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -149,7 +149,12 @@ def dm_request(stop_name: str, limit: int = 10) -> Dict[str, Any]:
 def stopfinder_request(query: str) -> Dict[str, Any]:
     """Return stop suggestions for the given search string."""
     url = f"{BASE_URL}/XML_STOPFINDER_REQUEST"
-    params = {"odvSugMacro": 1, "name_sf": query, "outputFormat": "JSON"}
+    params = {
+        "odvSugMacro": 1,
+        "name_sf": query,
+        "outputFormat": "JSON",
+        "locationServerActive": 1,
+    }
     logger.info("Stop finder for query '%s'", query)
     logger.debug("StopFinder params: %s", params)
     response = requests.get(url, params=params, timeout=10)

--- a/tests/test_efa_api.py
+++ b/tests/test_efa_api.py
@@ -121,5 +121,7 @@ def test_stopfinder_request_returns_json(mock_get):
     args, kwargs = mock_get.call_args
     assert args[0].endswith('/XML_STOPFINDER_REQUEST')
     assert kwargs['params']['name_sf'] == 'Bruneck'
+    assert kwargs['params']['odvSugMacro'] == 1
+    assert kwargs['params']['locationServerActive'] == 1
     assert result == {'stops': []}
 


### PR DESCRIPTION
## Summary
- include `locationServerActive=1` in `stopfinder_request`
- check the new params in tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68651c2620f08321b475beb1c31f5901