### PR TITLE
Add stopfinder logging to trip search

### DIFF
--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -40,6 +40,8 @@ def get_stop_code(query: str) -> str:
         if isinstance(points, dict):
             points = [points]
 
+        logger.info("StopFinder results for '%s': %s", query, points)
+
         best: Optional[Dict[str, Any]] = None
         best_quality = -1
         for p in points:


### PR DESCRIPTION
## Summary
- log StopFinder results when resolving stop names

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865203861d48321b050277b5ce4fd83