### PR TITLE
Remove SM_DEBUG; add file logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,11 @@ showing the results.
 
 ### Debug mode
 
-Enable verbose logging for both the CLI and the server by setting the
-`SM_DEBUG` environment variable or passing `--debug` to the CLI:
+Enable verbose logging for both the CLI and the server by passing
+`--debug` to the CLI. Logs are also written to `app.log`:
 
 ```bash
-SM_DEBUG=1 python -m src.cli search "Bozen nach Meran"
+python -m src.cli search "Bozen nach Meran" --debug
 ```
 
 

--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -1,15 +1,15 @@
 import logging
-import os
-from typing import Optional
 
 
-def setup_logging(debug: Optional[bool] = None) -> None:
+def setup_logging(debug: bool = False, log_file: str = "app.log") -> None:
     """Configure basic logging for the application."""
-    if debug is None:
-        debug = os.environ.get("SM_DEBUG") in {"1", "true", "True"}
     level = logging.DEBUG if debug else logging.INFO
     # Only configure root logger if it hasn't been configured yet
     if not logging.getLogger().handlers:
-        logging.basicConfig(level=level, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+        logging.basicConfig(
+            level=level,
+            format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            handlers=[logging.StreamHandler(), logging.FileHandler(log_file)],
+        )
     else:
         logging.getLogger().setLevel(level)

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,6 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 import logging
-import os
 
 from . import nlp_parser, efa_api
 from .summaries import (
@@ -12,7 +11,8 @@ from .summaries import (
 )
 from .logging_utils import setup_logging
 
-setup_logging(os.environ.get("SM_DEBUG") in {"1", "true", "True"})
+# Configure logging; debug mode is controlled solely via CLI arguments
+setup_logging()
 logger = logging.getLogger(__name__)
 
 app = FastAPI()


### PR DESCRIPTION
## Summary
- remove `SM_DEBUG` environment variable support
- output logs to `app.log`
- document debug mode usage without env var

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686525f1c36883218e21b3f80285b0a9