### PR TITLE
Fix stop finder output for list responses

### DIFF
--- a/src/summaries.py
+++ b/src/summaries.py
@@ -195,9 +195,20 @@ def format_stops_result(result: Dict[str, Any]) -> str:
         return str(result)
 
     # Gracefully handle missing or null fields in the nested structure
-    stopfinder = result.get("stopFinder") or {}
-    points_data = stopfinder.get("points") or {}
-    points = points_data.get("point") or result.get("stops")
+    stopfinder = result.get("stopFinder")
+    if not isinstance(stopfinder, dict):
+        stopfinder = {}
+
+    points_data = stopfinder.get("points")
+    if isinstance(points_data, dict):
+        points = points_data.get("point")
+    elif isinstance(points_data, list):
+        points = points_data
+    else:
+        points = None
+
+    if not points:
+        points = result.get("stops")
     names: List[str] = []
     if isinstance(points, list):
         for p in points:

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -13,3 +13,12 @@ def test_format_stops_result_handles_null_stopfinder():
 def test_format_stops_result_handles_null_points():
     result = {"stopFinder": {"points": None}}
     assert format_stops_result(result) == "0 stops found."
+
+
+def test_format_stops_result_handles_points_list():
+    result = {"stopFinder": {"points": [{"name": "A"}, {"name": "B"}]}}
+    assert (
+        format_stops_result(result)
+        == "Gefundene Haltestellen:\nA\nB"
+    )
+


### PR DESCRIPTION
## Summary
- handle list `points` in `format_stops_result`
- add regression test for stop list output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865276567b48321827d20ecc72dface