### PR TITLE
Improve summaries

### DIFF
--- a/src/summaries.py
+++ b/src/summaries.py
@@ -60,45 +60,19 @@ def format_search_result(result: Dict[str, Any]) -> str:
         leg_list = []
 
     lines: List[str] = []
-    if leg_list:
-        first_leg = leg_list[0]
-        origin = first_leg.get("origin") or first_leg.get("departure") or {}
-        dest = first_leg.get("destination") or first_leg.get("arrival") or {}
-        start_name = origin.get("name") or from_stop
-        start_time = origin.get("time") or ""
-        mode_name = (
-            (first_leg.get("mode") or {}).get("name")
-            or (first_leg.get("mode") or {}).get("number")
-            or ""
-        )
-        if not mode_name or "fuß" in mode_name.lower() or "walk" in mode_name.lower():
-            mode_desc = "zu Fuß"
-        else:
-            mode_desc = f"mit {mode_name}"
-        origin_line = f"Von: {start_name}"
-        if start_time:
-            origin_line += f" um {start_time} Uhr {mode_desc}"
-        else:
-            origin_line += f" {mode_desc}"
-        lines.append(origin_line)
-        dest_name = dest.get("name") or to_stop
-        lines.append(f"Nach: {dest_name}")
-    else:
-        start_name = from_stop
-        lines.append(f"Von: {start_name}")
-        if to_stop:
-            lines.append(f"Nach: {to_stop}")
 
-    if leg_list:
-        lines.append("")
-
-    for leg in leg_list:
+    for idx, leg in enumerate(leg_list):
         origin = leg.get("origin") or leg.get("departure") or {}
         dest = leg.get("destination") or leg.get("arrival") or {}
+        points = leg.get("points")
+        if not origin and isinstance(points, list) and points:
+            origin = points[0]
+        if not dest and isinstance(points, list) and points:
+            dest = points[-1]
         o_name = origin.get("name", "")
-        o_time = origin.get("time", "")
+        o_time = origin.get("time") or (origin.get("dateTime") or {}).get("time", "")
         d_name = dest.get("name", "")
-        d_time = dest.get("time", "")
+        d_time = dest.get("time") or (dest.get("dateTime") or {}).get("time", "")
         line_name = (
             (leg.get("mode") or {}).get("name")
             or (leg.get("mode") or {}).get("number")
@@ -116,6 +90,9 @@ def format_search_result(result: Dict[str, Any]) -> str:
             dep_line += f" um {o_time} Uhr {line_desc}"
         else:
             dep_line += f" {line_desc}"
+        origin_platform = origin.get("platform") or origin.get("platformName")
+        if origin_platform:
+            dep_line += f" von Steig {origin_platform}"
         arr_line = f"An: {d_name}"
         if d_time:
             arr_line += f" um {d_time} Uhr"
@@ -124,6 +101,8 @@ def format_search_result(result: Dict[str, Any]) -> str:
             arr_line += f" auf Steig {platform}"
         lines.append(dep_line)
         lines.append(arr_line)
+        if idx < len(leg_list) - 1:
+            lines.append("")
 
     return "\n".join(lines)
 
@@ -171,19 +150,25 @@ def format_departures_result(result: Dict[str, Any]) -> str:
             or ""
         )
         line_info = dep.get("servingLine") or dep.get("line") or {}
-        line_name = line_info.get("name") or line_info.get("number") or ""
+        line_name = line_info.get("name") or ""
+        line_number = line_info.get("number") or ""
+        line_display = line_name
+        if line_number and line_number not in line_display:
+            line_display = f"{line_display} {line_number}".strip()
         direction = line_info.get("direction") or line_info.get("destination") or ""
-        platform = dep.get("platform") or dep.get("platformName")
+        platform = dep.get("platformName") or dep.get("platform")
 
-        entry = time
-        if entry:
-            entry += " Uhr"
-        if line_name:
-            entry += f" {line_name}"
+        parts = []
+        if line_display:
+            parts.append(line_display)
         if direction:
-            entry += f" Richtung {direction}"
+            parts.append(f"Richtung {direction}")
         if platform:
-            entry += f" Steig {platform}"
+            parts.append(f"Steig {platform}")
+        if time:
+            parts.append(f"um {time} Uhr")
+
+        entry = " ".join(parts)
         lines.append(entry.strip())
 
     return "\n".join(lines)
@@ -209,18 +194,47 @@ def format_stops_result(result: Dict[str, Any]) -> str:
 
     if not points:
         points = result.get("stops")
-    names: List[str] = []
+    results: List[Dict[str, Any]] = []
     if isinstance(points, list):
         for p in points:
-            if isinstance(p, dict) and p.get("name"):
-                names.append(p["name"])
+            if not isinstance(p, dict) or not p.get("name"):
+                continue
+            entry = p["name"]
+            any_type = p.get("anyType") or p.get("type")
+            if any_type:
+                entry += f" ({any_type})"
+            try:
+                quality = int(p.get("quality"))
+            except (TypeError, ValueError):
+                quality = -1
+            results.append({"entry": entry, "quality": quality, "type": any_type or ""})
     elif isinstance(points, dict):
         if points.get("name"):
-            names.append(points["name"])
+            entry = points["name"]
+            any_type = points.get("anyType") or points.get("type")
+            if any_type:
+                entry += f" ({any_type})"
+            try:
+                quality = int(points.get("quality"))
+            except (TypeError, ValueError):
+                quality = -1
+            results.append({"entry": entry, "quality": quality, "type": any_type or ""})
 
-    if not names:
+    if not results:
         return "0 stops found."
 
+    type_order = {"stop": 0, "location": 1, "address": 2, "street": 3}
+    results.sort(key=lambda r: (type_order.get(r["type"], 99), r["entry"]))
+
+    best_idx = None
+    if any(r["quality"] >= 0 for r in results):
+        best_idx = max(range(len(results)), key=lambda i: results[i]["quality"]) 
+
     lines = ["Gefundene Haltestellen:"]
-    lines.extend(names)
+    for idx, r in enumerate(results):
+        line = r["entry"]
+        if best_idx is not None and idx == best_idx:
+            line += " [beste]"
+        lines.append(line)
+
     return "\n".join(lines)

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -3,6 +3,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from src.summaries import format_stops_result
+from src.summaries import format_search_result, format_departures_result
 
 
 def test_format_stops_result_handles_null_stopfinder():
@@ -16,9 +17,105 @@ def test_format_stops_result_handles_null_points():
 
 
 def test_format_stops_result_handles_points_list():
-    result = {"stopFinder": {"points": [{"name": "A"}, {"name": "B"}]}}
-    assert (
-        format_stops_result(result)
-        == "Gefundene Haltestellen:\nA\nB"
-    )
+    result = {
+        "stopFinder": {
+            "points": [
+                {"name": "A", "anyType": "stop", "quality": "10"},
+                {"name": "B", "anyType": "location", "quality": "20"},
+            ]
+        }
+    }
+    summary = format_stops_result(result)
+    assert "Gefundene Haltestellen:" in summary
+    lines = summary.splitlines()
+    # first entry should be the stop type
+    assert lines[1].startswith("A (stop)")
+    # best result flagged on line with highest quality
+    assert any("B (location) [beste]" in l for l in lines)
+
+
+def test_format_search_result_handles_points_leg():
+    result = {
+        "trips": {
+            "trip": {
+                "legs": [
+                    {
+                        "points": [
+                            {
+                                "name": "Start",
+                                "platformName": "B",
+                                "dateTime": {"time": "10:00"},
+                            },
+                            {
+                                "name": "End",
+                                "platformName": "F",
+                                "dateTime": {"time": "10:30"},
+                            },
+                        ],
+                        "mode": {"name": "Bus B123", "destination": "End"},
+                    }
+                ]
+            }
+        }
+    }
+
+    summary = format_search_result(result)
+    assert "Ab: Start" in summary
+    assert "um 10:00 Uhr" in summary
+    assert "von Steig B" in summary
+    assert "An: End" in summary
+    assert "um 10:30 Uhr" in summary
+    assert "auf Steig F" in summary
+
+
+def test_format_search_result_multiple_legs_separated():
+    result = {
+        "trips": {
+            "trip": {
+                "legs": [
+                    {
+                        "origin": {"name": "A", "platformName": "F", "time": "10:00"},
+                        "destination": {"name": "B", "platformName": "1", "time": "10:30"},
+                        "mode": {"name": "Bus B200", "destination": "B"},
+                    },
+                    {
+                        "origin": {"name": "B", "platformName": "2", "time": "10:40"},
+                        "destination": {"name": "C", "platformName": "3", "time": "11:00"},
+                        "mode": {"name": "Bus B300", "destination": "C"},
+                    },
+                ]
+            }
+        }
+    }
+
+    summary = format_search_result(result)
+    lines = summary.splitlines()
+    # ensure there is an empty line separating the two legs
+    assert "" in lines
+    assert lines[0].startswith("Ab: A")
+    assert lines[2] == ""
+    assert lines[3].startswith("Ab: B")
+
+
+def test_format_departures_result_formats_line():
+    result = {
+        "stop_name": "Brixen",
+        "departures": {
+            "departure": [
+                {
+                    "time": "13:20",
+                    "servingLine": {
+                        "name": "Bus",
+                        "number": "401",
+                        "direction": "Brixen Bahnhof",
+                    },
+                    "platformName": "A",
+                }
+            ]
+        },
+    }
+
+    summary = format_departures_result(result)
+    assert "Abfahrten f" in summary
+    assert "Bus 401 Richtung Brixen Bahnhof Steig A um 13:20 Uhr" in summary
 


### PR DESCRIPTION
## Summary
- include line number and platform name in departures
- sort stop results by type and mark best result
- list only legs in search summaries with blank lines between legs
- add regression tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68652a933f2483218e65a61765f5da54