### PR TITLE
Improve trip and departures formatting

### DIFF
--- a/src/summaries.py
+++ b/src/summaries.py
@@ -13,16 +13,8 @@ def format_search_result(result: Dict[str, Any]) -> str:
     if not isinstance(result, dict):
         return str(result)
 
-    from_stop = (
-        result.get("from_stop")
-        or result.get("origin", {}).get("name")
-        or ""
-    )
-    to_stop = (
-        result.get("to_stop")
-        or result.get("destination", {}).get("name")
-        or ""
-    )
+    from_stop = result.get("from_stop") or result.get("origin", {}).get("name") or ""
+    to_stop = result.get("to_stop") or result.get("destination", {}).get("name") or ""
 
     raw_trips = result.get("trips")
     trips: List[Dict[str, Any]] = []
@@ -60,44 +52,8 @@ def format_search_result(result: Dict[str, Any]) -> str:
         leg_list = []
 
     lines: List[str] = []
-    if leg_list:
-        first_leg = leg_list[0]
-        origin = first_leg.get("origin") or first_leg.get("departure") or {}
-        dest = first_leg.get("destination") or first_leg.get("arrival") or {}
-        points = first_leg.get("points")
-        if not origin and isinstance(points, list) and points:
-            origin = points[0]
-        if not dest and isinstance(points, list) and points:
-            dest = points[-1]
-        start_name = origin.get("name") or from_stop
-        start_time = origin.get("time") or (origin.get("dateTime") or {}).get("time", "")
-        mode_name = (
-            (first_leg.get("mode") or {}).get("name")
-            or (first_leg.get("mode") or {}).get("number")
-            or ""
-        )
-        if not mode_name or "fuß" in mode_name.lower() or "walk" in mode_name.lower():
-            mode_desc = "zu Fuß"
-        else:
-            mode_desc = f"mit {mode_name}"
-        origin_line = f"Von: {start_name}"
-        if start_time:
-            origin_line += f" um {start_time} Uhr {mode_desc}"
-        else:
-            origin_line += f" {mode_desc}"
-        lines.append(origin_line)
-        dest_name = dest.get("name") or to_stop
-        lines.append(f"Nach: {dest_name}")
-    else:
-        start_name = from_stop
-        lines.append(f"Von: {start_name}")
-        if to_stop:
-            lines.append(f"Nach: {to_stop}")
 
-    if leg_list:
-        lines.append("")
-
-    for leg in leg_list:
+    for idx, leg in enumerate(leg_list):
         origin = leg.get("origin") or leg.get("departure") or {}
         dest = leg.get("destination") or leg.get("arrival") or {}
         points = leg.get("points")
@@ -137,6 +93,8 @@ def format_search_result(result: Dict[str, Any]) -> str:
             arr_line += f" auf Steig {platform}"
         lines.append(dep_line)
         lines.append(arr_line)
+        if idx < len(leg_list) - 1:
+            lines.append("")
 
     return "\n".join(lines)
 
@@ -160,7 +118,11 @@ def format_departures_result(result: Dict[str, Any]) -> str:
         or result.get("stopEvents")
     )
     if isinstance(raw_departures, dict):
-        dep_items = raw_departures.get("departure") or raw_departures.get("stopEvent") or raw_departures
+        dep_items = (
+            raw_departures.get("departure")
+            or raw_departures.get("stopEvent")
+            or raw_departures
+        )
     else:
         dep_items = raw_departures
 
@@ -184,9 +146,12 @@ def format_departures_result(result: Dict[str, Any]) -> str:
             or ""
         )
         line_info = dep.get("servingLine") or dep.get("line") or {}
-        line_name = line_info.get("name") or line_info.get("number") or ""
+        line_name_part = line_info.get("name")
+        line_number_part = line_info.get("number")
+        line_parts = [p for p in (line_name_part, line_number_part) if p]
+        line_name = " ".join(line_parts)
         direction = line_info.get("direction") or line_info.get("destination") or ""
-        platform = dep.get("platform") or dep.get("platformName")
+        platform = dep.get("platformName")
 
         parts = []
         if line_name:
@@ -224,44 +189,42 @@ def format_stops_result(result: Dict[str, Any]) -> str:
 
     if not points:
         points = result.get("stops")
-    entries: List[str] = []
-    qualities: List[int] = []
+    entries: List[Dict[str, Any]] = []
+    best_entry = None
+    best_quality = -1
     if isinstance(points, list):
-        for p in points:
-            if not isinstance(p, dict) or not p.get("name"):
-                continue
-            entry = p["name"]
-            any_type = p.get("anyType") or p.get("type")
-            if any_type:
-                entry += f" ({any_type})"
-            entries.append(entry)
-            try:
-                qualities.append(int(p.get("quality")))
-            except (TypeError, ValueError):
-                qualities.append(-1)
+        iterable = points
     elif isinstance(points, dict):
-        if points.get("name"):
-            entry = points["name"]
-            any_type = points.get("anyType") or points.get("type")
-            if any_type:
-                entry += f" ({any_type})"
-            entries.append(entry)
-            try:
-                qualities.append(int(points.get("quality")))
-            except (TypeError, ValueError):
-                qualities.append(-1)
+        iterable = [points]
+    else:
+        iterable = []
+
+    for p in iterable:
+        if not isinstance(p, dict) or not p.get("name"):
+            continue
+        entry_text = p["name"]
+        any_type = p.get("anyType") or p.get("type") or ""
+        if any_type:
+            entry_text += f" ({any_type})"
+        try:
+            quality = int(p.get("quality"))
+        except (TypeError, ValueError):
+            quality = -1
+        entry = {"text": entry_text, "type": any_type, "quality": quality}
+        entries.append(entry)
+        if quality > best_quality:
+            best_quality = quality
+            best_entry = entry
 
     if not entries:
         return "0 stops found."
-
-    best_idx = None
-    if qualities and any(q >= 0 for q in qualities):
-        best_idx = max(range(len(qualities)), key=lambda i: qualities[i])
+    entries.sort(key=lambda e: e["type"])
+    best_idx = entries.index(best_entry) if best_entry in entries else None
 
     lines = ["Gefundene Haltestellen:"]
     for idx, entry in enumerate(entries):
         if best_idx is not None and idx == best_idx:
-            lines.append(f"{entry} [beste]")
+            lines.append(f"[TOP] {entry['text']}")
         else:
-            lines.append(entry)
+            lines.append(entry["text"])
     return "\n".join(lines)

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -29,7 +29,8 @@ def test_format_stops_result_handles_points_list():
     assert "Gefundene Haltestellen:" in summary
     assert "A (stop)" in summary
     assert "B (location)" in summary
-    assert "[beste]" in summary
+    assert "[TOP]" in summary
+    assert "[TOP]" in summary.splitlines()[1]
 
 
 def test_format_search_result_handles_points_leg():
@@ -88,4 +89,44 @@ def test_format_departures_result_formats_line():
     assert (
         "Citybus 320.1 Richtung Milland KG Arcobaleno Steig A um 13:20 Uhr" in summary
     )
+
+
+def test_format_departures_result_includes_number():
+    result = {
+        "departures": {
+            "departure": [
+                {
+                    "time": "08:00",
+                    "servingLine": {
+                        "name": "Bus sostitutivo",
+                        "number": "B200",
+                        "direction": "Merano Express",
+                    },
+                    "platformName": "F",
+                }
+            ]
+        }
+    }
+
+    summary = format_departures_result(result)
+    assert "Bus sostitutivo B200" in summary
+    assert "Steig F" in summary
+
+
+def test_format_departures_result_omits_missing_platform_name():
+    result = {
+        "departures": {
+            "departure": [
+                {
+                    "time": "09:15",
+                    "servingLine": {"name": "Bus", "number": "10"},
+                    "platform": "1",
+                }
+            ]
+        }
+    }
+
+    summary = format_departures_result(result)
+    assert "09:15" in summary
+    assert "Steig" not in summary
 


### PR DESCRIPTION
## Summary
- format each trip leg without a preceding heading
- show line names with numbers and prefer platformName
- keep stop suggestions sorted by type with the best match labeled `[TOP]`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686532e2dacc8321bd1bbc590988e49d