### PR TITLE
Add legs-only summary function

### DIFF
--- a/src/summaries.py
+++ b/src/summaries.py
@@ -143,6 +143,86 @@ def format_search_result(result: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def format_search_result_legs_only(result: Dict[str, Any]) -> str:
+    """Return only the legs of a search result as plain text."""
+    if not isinstance(result, dict):
+        return str(result)
+
+    raw_trips = result.get("trips")
+    trips: List[Dict[str, Any]] = []
+    if isinstance(raw_trips, list):
+        trips = raw_trips
+    elif isinstance(raw_trips, dict):
+        trip_data = raw_trips.get("trip")
+        if isinstance(trip_data, list):
+            trips = trip_data
+        elif isinstance(trip_data, dict):
+            trips = [trip_data]
+        elif raw_trips:
+            trips = [raw_trips]
+
+    if not trips:
+        return "0 legs found."
+
+    trip = trips[0]
+    legs = trip.get("legs") or trip.get("legList") or {}
+    if isinstance(legs, dict):
+        leg_items = legs.get("leg") or legs
+    else:
+        leg_items = legs
+    if isinstance(leg_items, dict):
+        leg_list = [leg_items]
+    elif isinstance(leg_items, list):
+        leg_list = leg_items
+    else:
+        leg_list = []
+
+    lines: List[str] = []
+    for idx, leg in enumerate(leg_list):
+        origin = leg.get("origin") or leg.get("departure") or {}
+        dest = leg.get("destination") or leg.get("arrival") or {}
+        points = leg.get("points")
+        if not origin and isinstance(points, list) and points:
+            origin = points[0]
+        if not dest and isinstance(points, list) and points:
+            dest = points[-1]
+
+        o_name = origin.get("name", "")
+        o_time = origin.get("time") or (origin.get("dateTime") or {}).get("time", "")
+        d_name = dest.get("name", "")
+        d_time = dest.get("time") or (dest.get("dateTime") or {}).get("time", "")
+
+        mode = leg.get("mode") or {}
+        line_name = mode.get("name") or mode.get("number") or ""
+        direction = mode.get("destination") or ""
+
+        if not line_name or "fuß" in line_name.lower() or "walk" in line_name.lower():
+            line_header = "Zu Fuß"
+        else:
+            line_header = line_name
+            if direction:
+                line_header += f" Richtung {direction}"
+
+        lines.append(line_header)
+
+        dep_line = f"{o_time}: {o_name}" if o_time else o_name
+        origin_platform = origin.get("platform") or origin.get("platformName")
+        if origin_platform:
+            dep_line += f" von Steig {origin_platform}"
+        lines.append(dep_line.strip())
+
+        arr_line = f"{d_time}: {d_name}" if d_time else d_name
+        platform = dest.get("platform") or dest.get("platformName")
+        if platform:
+            arr_line += f" auf Steig {platform}"
+        lines.append(arr_line.strip())
+
+        if idx < len(leg_list) - 1:
+            lines.append("")
+
+    return "\n".join(lines)
+
+
 def format_departures_result(result: Dict[str, Any]) -> str:
     """Return a readable summary of departures."""
     if not isinstance(result, dict):

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -2,8 +2,12 @@ import os
 import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from src.summaries import format_stops_result
-from src.summaries import format_search_result, format_departures_result
+from src.summaries import (
+    format_stops_result,
+    format_search_result,
+    format_departures_result,
+    format_search_result_legs_only,
+)
 
 
 def test_format_stops_result_handles_null_stopfinder():
@@ -110,4 +114,53 @@ def test_format_departures_result_includes_number():
     summary = format_departures_result(result)
     assert "Bus sostitutivo B200" in summary
     assert "Steig F" in summary
+
+
+def test_format_search_result_legs_only():
+    result = {
+        "trips": {
+            "trip": {
+                "legs": [
+                    {
+                        "origin": {
+                            "name": "Bolzano, Stazione di Bolzano",
+                            "platformName": "1",
+                            "time": "16:36",
+                        },
+                        "destination": {
+                            "name": "Termeno sulla Strada del Vino, Stazione di Egna - Termeno",
+                            "platformName": "1",
+                            "time": "17:00",
+                        },
+                        "mode": {
+                            "name": "Treno regionale R 16697",
+                            "destination": "Verona Porta Nuova",
+                        },
+                    },
+                    {
+                        "origin": {
+                            "name": "Termeno sulla Strada del Vino, Stazione di Egna - Termeno",
+                            "time": "17:11",
+                        },
+                        "destination": {
+                            "name": "Villa, Villa di Sopra",
+                            "time": "17:18",
+                        },
+                        "mode": {
+                            "name": "Bus 142",
+                            "destination": "Aldino - Pietralba",
+                        },
+                    },
+                ]
+            }
+        }
+    }
+
+    summary = format_search_result_legs_only(result)
+    assert "Treno regionale R 16697 Richtung Verona Porta Nuova" in summary
+    assert "16:36: Bolzano, Stazione di Bolzano von Steig 1" in summary
+    assert "17:00: Termeno sulla Strada del Vino, Stazione di Egna - Termeno auf Steig 1" in summary
+    assert "Bus 142 Richtung Aldino - Pietralba" in summary
+    assert "17:11: Termeno sulla Strada del Vino, Stazione di Egna - Termeno" in summary
+    assert "17:18: Villa, Villa di Sopra" in summary
 


### PR DESCRIPTION
## Summary
- extend summaries with `format_search_result_legs_only` to list only trip legs
- test the new summary helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686539f557708321acf212bb6a160a98