### PR TITLE
Log stateless ID for stops before trip searches

### DIFF
--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -60,6 +60,10 @@ def get_stop_code(query: str) -> str:
 
         logger.debug("Stop suggestions: %s", points)
         logger.debug("Best match: %s", best)
+        if best and best.get("stateless"):
+            logger.info(
+                "StopFinder stateless ID for '%s': %s", query, best["stateless"]
+            )
 
         if best:
             if best.get("stateless"):


### PR DESCRIPTION
## Summary
- log the stateless ID selected by `get_stop_code`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653b1f287c8321bac50049c760646b