### PR TITLE
Add legs-only summary format

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -20,8 +20,9 @@ def run_search(query: str, output_format: str = "text") -> None:
     query: str
         Natural language query describing the trip request.
     output_format: str, optional
-        Either ``"text"`` or ``"json"``. ``"text"`` prints a short summary while
-        ``"json"`` dumps the raw API response.
+        ``"text"`` prints a short summary,
+        ``"json"`` dumps the raw API response,
+        ``"legs"`` shows only the individual trip legs.
     """
     logger.info("Searching for stops...")
     params = nlp_parser.parse_query(query)
@@ -49,6 +50,8 @@ def run_search(query: str, output_format: str = "text") -> None:
         import json
 
         print(json.dumps(response, ensure_ascii=False, indent=2))
+    elif output_format == "legs":
+        print(format_search_result(response, legs_only=True))
     else:
         print(format_search_result(response))
 
@@ -103,7 +106,7 @@ if __name__ == "__main__":
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     parser.add_argument(
         "--format",
-        choices=["text", "json"],
+        choices=["text", "json", "legs"],
         default="text",
         help="Output format",
     )

--- a/src/main.py
+++ b/src/main.py
@@ -38,6 +38,8 @@ def search(req: SearchRequest, format: str = "json"):
     logger.debug("/search result: %s", result)
     if format == "text":
         return PlainTextResponse(format_search_result(result))
+    if format == "legs":
+        return PlainTextResponse(format_search_result(result, legs_only=True))
     return result
 
 

--- a/src/summaries.py
+++ b/src/summaries.py
@@ -27,8 +27,17 @@ def _plural(word: str, count: int) -> str:
     return word if count == 1 else f"{word}s"
 
 
-def format_search_result(result: Dict[str, Any]) -> str:
-    """Return a readable summary of a trip search result."""
+def format_search_result(result: Dict[str, Any], legs_only: bool = False) -> str:
+    """Return a readable summary of a trip search result.
+
+    Parameters
+    ----------
+    result: dict
+        Parsed trip search response.
+    legs_only: bool, optional
+        If ``True`` only the individual trip legs are returned without the
+        introductory "Von"/"Nach" lines.
+    """
     if not isinstance(result, dict):
         return str(result)
 
@@ -79,7 +88,7 @@ def format_search_result(result: Dict[str, Any]) -> str:
         leg_list = []
 
     lines: List[str] = []
-    if leg_list:
+    if leg_list and not legs_only:
         first_leg = leg_list[0]
         origin = first_leg.get("origin") or first_leg.get("departure") or {}
         dest = first_leg.get("destination") or first_leg.get("arrival") or {}
@@ -107,13 +116,13 @@ def format_search_result(result: Dict[str, Any]) -> str:
         lines.append(origin_line)
         dest_name = dest.get("name") or to_stop
         lines.append(f"Nach: {dest_name}")
-    else:
+    elif not legs_only:
         start_name = from_stop
         lines.append(f"Von: {start_name}")
         if to_stop:
             lines.append(f"Nach: {to_stop}")
 
-    if leg_list:
+    if leg_list and not legs_only:
         lines.append("")
 
     for idx, leg in enumerate(leg_list):
@@ -134,28 +143,47 @@ def format_search_result(result: Dict[str, Any]) -> str:
             or ""
         )
         if not line_name or "fuß" in line_name.lower() or "walk" in line_name.lower():
-            line_desc = "zu Fuß"
+            if legs_only:
+                line_desc = "zu Fuß"
+            else:
+                line_desc = "zu Fuß"
         else:
-            line_desc = f"mit {line_name}"
+            if legs_only:
+                line_desc = line_name
+            else:
+                line_desc = f"mit {line_name}"
             direction = (leg.get("mode") or {}).get("destination") or ""
             if direction:
                 line_desc += f" Richtung {direction}"
-        dep_line = f"Ab: {o_name}"
-        if o_time:
-            dep_line += f" um {o_time} Uhr {line_desc}"
+        if legs_only:
+            lines.append(line_desc)
+            start_line = f"{o_time}: {o_name}" if o_time else o_name
+            origin_platform = origin.get("platform") or origin.get("platformName")
+            if origin_platform:
+                start_line += f" von Steig {origin_platform}"
+            lines.append(start_line)
+            end_line = f"{d_time}: {d_name}" if d_time else d_name
+            platform = dest.get("platform") or dest.get("platformName")
+            if platform:
+                end_line += f" auf Steig {platform}"
+            lines.append(end_line)
         else:
-            dep_line += f" {line_desc}"
-        origin_platform = origin.get("platform") or origin.get("platformName")
-        if origin_platform:
-            dep_line += f" von Steig {origin_platform}"
-        arr_line = f"An: {d_name}"
-        if d_time:
-            arr_line += f" um {d_time} Uhr"
-        platform = dest.get("platform") or dest.get("platformName")
-        if platform:
-            arr_line += f" auf Steig {platform}"
-        lines.append(dep_line)
-        lines.append(arr_line)
+            dep_line = f"Ab: {o_name}"
+            if o_time:
+                dep_line += f" um {o_time} Uhr {line_desc}"
+            else:
+                dep_line += f" {line_desc}"
+            origin_platform = origin.get("platform") or origin.get("platformName")
+            if origin_platform:
+                dep_line += f" von Steig {origin_platform}"
+            arr_line = f"An: {d_name}"
+            if d_time:
+                arr_line += f" um {d_time} Uhr"
+            platform = dest.get("platform") or dest.get("platformName")
+            if platform:
+                arr_line += f" auf Steig {platform}"
+            lines.append(dep_line)
+            lines.append(arr_line)
         if idx < len(leg_list) - 1:
             lines.append("")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,3 +22,13 @@ def test_run_search_json(mock_parse, mock_search, capsys):
     cli.run_search('foo', output_format='json')
     captured = capsys.readouterr()
     assert json.loads(captured.out) == {'foo': 'bar'}
+
+
+@patch('src.cli.format_search_result', return_value='legs')
+@patch('src.cli.efa_api.search_efa', return_value={'ok': True})
+@patch('src.cli.nlp_parser.parse_query', return_value={'from_stop': 'A', 'to_stop': 'B'})
+def test_run_search_legs(mock_parse, mock_search, mock_format, capsys):
+    cli.run_search('foo', output_format='legs')
+    captured = capsys.readouterr()
+    assert captured.out.strip() == 'legs'
+    mock_format.assert_called_once_with({'ok': True}, legs_only=True)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,7 +30,20 @@ def test_search_endpoint_text(mock_parse_query, mock_search_efa, mock_format):
     response = client.post('/search?format=text', json={'text': 'foo'})
     assert response.status_code == 200
     assert response.text == 'summary'
-    mock_format.assert_called_once()
+    mock_format.assert_called_once_with({'dummy': True}, legs_only=False)
+
+
+@patch('src.main.format_search_result', return_value='legs')
+@patch('src.main.efa_api.search_efa')
+@patch('src.main.nlp_parser.parse_query')
+def test_search_endpoint_legs(mock_parse_query, mock_search_efa, mock_format):
+    mock_parse_query.return_value = {'from_stop': 'A', 'to_stop': 'B'}
+    mock_search_efa.return_value = {'dummy': True}
+    client = TestClient(app)
+    response = client.post('/search?format=legs', json={'text': 'foo'})
+    assert response.status_code == 200
+    assert response.text == 'legs'
+    mock_format.assert_called_once_with({'dummy': True}, legs_only=True)
 
 
 @patch('src.main.efa_api.dm_request')

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -144,6 +144,27 @@ def test_format_search_result_structured_time():
     assert "um 10:35 Uhr" in summary
 
 
+def test_format_search_result_legs_only():
+    result = {
+        "trips": {
+            "trip": {
+                "legs": [
+                    {
+                        "origin": {"name": "A", "platformName": "1", "time": "08:00"},
+                        "destination": {"name": "B", "platformName": "2", "time": "08:30"},
+                        "mode": {"name": "Bus 10", "destination": "B"},
+                    }
+                ]
+            }
+        }
+    }
+
+    summary = format_search_result(result, legs_only=True)
+    assert summary.startswith("Bus 10 Richtung B")
+    assert "08:00: A von Steig 1" in summary
+    assert "08:30: B auf Steig 2" in summary
+
+
 def test_format_departures_result_structured_time():
     result = {
         "departures": {


### PR DESCRIPTION
## Summary
- support new `legs_only` mode in `format_search_result`
- handle `--format legs` in CLI
- expose `format=legs` in API
- test new functionality

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68653bcd9b8c8321a9427a851b77811b