### PR TITLE
Include UTF-8 outputEncoding for all EFA calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ EFA_BASE_URL=https://efa.sta.bz.it/apb uvicorn src.main:app --host 0.0.0.0 --rel
 
 All requests automatically enable the EFA location server via
 `locationServerActive=1`. Trip and departure monitor queries also send
-`odvMacro=true`.
+`odvMacro=true`. Starting with version 0.2 all requests specify
+`outputEncoding=UTF-8` to ensure UTF‑8 encoded responses.
 ## API endpoints
 
 The service exposes three POST endpoints:

--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -24,6 +24,7 @@ def get_stop_code(query: str) -> str:
         "name_sf": query,
         "outputFormat": "JSON",
         "locationServerActive": 1,
+        "outputEncoding": "UTF-8",
     }
 
     logger.debug("Requesting stop code for '%s'", query)
@@ -111,6 +112,7 @@ def search_efa(params: Dict[str, Any]) -> Dict[str, Any]:
         "calcNumberOfTrips": 1,
         "locationServerActive": 1,
         "odvMacro": "true",
+        "outputEncoding": "UTF-8",
     }
 
     time = params.get("time")
@@ -143,6 +145,7 @@ def dm_request(stop_name: str, limit: int = 10) -> Dict[str, Any]:
         "outputFormat": "JSON",
         "locationServerActive": 1,
         "odvMacro": "true",
+        "outputEncoding": "UTF-8",
     }
 
     logger.debug("DM request params: %s", params)
@@ -165,6 +168,7 @@ def stopfinder_request(query: str) -> Dict[str, Any]:
         "name_sf": query,
         "outputFormat": "JSON",
         "locationServerActive": 1,
+        "outputEncoding": "UTF-8",
     }
     logger.info("Stop finder for query '%s'", query)
     logger.debug("StopFinder params: %s", params)

--- a/src/main.py
+++ b/src/main.py
@@ -37,7 +37,7 @@ def search(req: SearchRequest, format: str = "json"):
     result = efa_api.search_efa(params)
     logger.debug("/search result: %s", result)
     if format == "text":
-        return PlainTextResponse(format_search_result(result))
+        return PlainTextResponse(format_search_result(result, legs_only=False))
     if format == "legs":
         return PlainTextResponse(format_search_result(result, legs_only=True))
     return result

--- a/tests/test_efa_api.py
+++ b/tests/test_efa_api.py
@@ -30,6 +30,7 @@ def test_get_stop_code(mock_get):
     mock_get.assert_called_once()
     args, kwargs = mock_get.call_args
     assert kwargs['params']['locationServerActive'] == 1
+    assert kwargs['params']['outputEncoding'] == 'UTF-8'
 
 
 @patch('src.efa_api.requests.get')
@@ -91,6 +92,7 @@ def test_search_efa_calls_requests(mock_get):
     assert efa_params['itdTime'] == '08:00'
     assert efa_params['locationServerActive'] == 1
     assert efa_params['odvMacro'] == 'true'
+    assert efa_params['outputEncoding'] == 'UTF-8'
     assert result == {'ok': True}
 
 
@@ -108,6 +110,7 @@ def test_dm_request_calls_requests(mock_get, mock_best):
     assert kwargs['params']['limit'] == 5
     assert kwargs['params']['locationServerActive'] == 1
     assert kwargs['params']['odvMacro'] == 'true'
+    assert kwargs['params']['outputEncoding'] == 'UTF-8'
     assert result == {'ok': True}
 
 
@@ -123,5 +126,6 @@ def test_stopfinder_request_returns_json(mock_get):
     assert kwargs['params']['name_sf'] == 'Bruneck'
     assert kwargs['params']['odvSugMacro'] == 'true'
     assert kwargs['params']['locationServerActive'] == 1
+    assert kwargs['params']['outputEncoding'] == 'UTF-8'
     assert result == {'stops': []}
 


### PR DESCRIPTION
## Summary
- add the `outputEncoding=UTF-8` parameter to every EFA request
- pass `legs_only=False` when formatting text results
- document the new parameter
- adjust tests for the new request parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653dbb9f648321802e76e6c846bce5