### PR TITLE
Default legs output for /search

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,18 +72,19 @@ The service exposes three POST endpoints:
 - `/stops` – return stop name suggestions
 
 
-After the server is running, you can query it with a POST request. By default
-the API returns JSON. Append `?format=text` to any endpoint for a short
-human‑readable summary:
+After the server is running, you can query it with a POST request. The `/search`
+endpoint returns a short plain‑text summary of the trip legs. Append
+`?format=json` if you need the raw JSON response. The other endpoints return
+JSON by default and accept `?format=text` for a short summary:
 
 ```bash
-# Trip request (JSON)
+# Trip request (plain text)
 curl -X POST http://localhost:8000/search \
      -H 'Content-Type: application/json' \
      -d '{"text": "Wie komme ich von Bozen nach Meran um 14:30?"}'
 
-# Trip request (plain text)
-curl -X POST 'http://localhost:8000/search?format=text' \
+# Trip request (JSON)
+curl -X POST 'http://localhost:8000/search?format=json' \
      -H 'Content-Type: application/json' \
      -d '{"text": "Wie komme ich von Bozen nach Meran um 14:30?"}'
 
@@ -132,8 +133,9 @@ python -m src.cli departures "Bozen"
 python -m src.cli stops "Brixen"
 ```
 
-By default the commands print a short text summary. To inspect the raw API
-response you need to enable debug mode and request the JSON output:
+By default the commands print a short text summary. For ``search`` this means
+showing only the individual trip legs. To inspect the raw API response you
+need to enable debug mode and request the JSON output:
 
 ```bash
 python -m src.cli search "Bozen nach Meran" --debug --format json

--- a/src/cli.py
+++ b/src/cli.py
@@ -12,7 +12,7 @@ from .summaries import (
 logger = logging.getLogger(__name__)
 
 
-def run_search(query: str, output_format: str = "text", debug: bool = False) -> None:
+def run_search(query: str, output_format: str = "legs", debug: bool = False) -> None:
     """Run a search for the given natural language query.
 
     Parameters
@@ -20,9 +20,9 @@ def run_search(query: str, output_format: str = "text", debug: bool = False) -> 
     query: str
         Natural language query describing the trip request.
     output_format: str, optional
-        ``"text"`` prints a short summary,
-        ``"json"`` dumps the raw API response,
-        ``"legs"`` shows only the individual trip legs.
+        ``"legs"`` prints only the individual trip legs,
+        ``"text"`` shows a longer summary,
+        ``"json"`` dumps the raw API response.
     """
     logger.info("Searching for stops...")
     params = nlp_parser.parse_query(query)
@@ -113,7 +113,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--format",
         choices=["text", "json", "legs"],
-        default="text",
+        default="legs",
         help="Output format",
     )
 

--- a/src/main.py
+++ b/src/main.py
@@ -29,18 +29,18 @@ class StopFinderRequest(BaseModel):
     query: str
 
 @app.post("/search")
-def search(req: SearchRequest, format: str = "json"):
+def search(req: SearchRequest, format: str = "legs"):
     logger.info("/search text='%s'", req.text)
     params = nlp_parser.parse_query(req.text)
     if not params:
         raise HTTPException(status_code=400, detail="No parameters extracted")
     result = efa_api.search_efa(params)
     logger.debug("/search result: %s", result)
+    if format == "json":
+        return result
     if format == "text":
         return PlainTextResponse(format_search_result(result, legs_only=False))
-    if format == "legs":
-        return PlainTextResponse(format_search_result(result, legs_only=True))
-    return result
+    return PlainTextResponse(format_search_result(result, legs_only=True))
 
 
 @app.post("/departures")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,7 +13,7 @@ def test_search_endpoint(mock_parse_query, mock_search_efa):
     expected_result = {'result': 'ok'}
     mock_search_efa.return_value = expected_result
     client = TestClient(app)
-    response = client.post('/search', json={'text': 'Wie komme ich von Bozen nach Meran?'})
+    response = client.post('/search?format=json', json={'text': 'Wie komme ich von Bozen nach Meran?'})
     assert response.status_code == 200
     assert response.json() == expected_result
     mock_parse_query.assert_called_once_with('Wie komme ich von Bozen nach Meran?')
@@ -40,7 +40,7 @@ def test_search_endpoint_legs(mock_parse_query, mock_search_efa, mock_format):
     mock_parse_query.return_value = {'from_stop': 'A', 'to_stop': 'B'}
     mock_search_efa.return_value = {'dummy': True}
     client = TestClient(app)
-    response = client.post('/search?format=legs', json={'text': 'foo'})
+    response = client.post('/search', json={'text': 'foo'})
     assert response.status_code == 200
     assert response.text == 'legs'
     mock_format.assert_called_once_with({'dummy': True}, legs_only=True)


### PR DESCRIPTION
## Summary
- adjust `/search` endpoint to return leg summaries by default
- update CLI to use leg output as the default
- document the new behaviour in README
- update tests to expect the new default

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68654111ff98832193ee41973d2195b4