### PR TITLE
Enable multilingual NLP query parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic
 uvicorn
 pytest
 httpx
+langdetect

--- a/src/nlp_parser.py
+++ b/src/nlp_parser.py
@@ -2,39 +2,76 @@ from typing import Dict, Optional
 import re
 import logging
 import spacy
+from langdetect import detect, DetectorFactory
 
 from .logging_utils import setup_logging
 
 logger = logging.getLogger(__name__)
 setup_logging()
 
-_nlp = None
+DetectorFactory.seed = 0
+
+_nlp_cache: Dict[str, spacy.Language] = {}
+
+LANG_MODELS = {
+    "de": "de_core_news_sm",
+    "en": "en_core_web_sm",
+    "it": "it_core_news_sm",
+}
+
+LANG_REGEX = {
+    "de": {
+        "from": re.compile(r"von\s+(\w+)", re.IGNORECASE),
+        "to": re.compile(r"nach\s+(\w+)", re.IGNORECASE),
+    },
+    "en": {
+        "from": re.compile(r"from\s+(\w+)", re.IGNORECASE),
+        "to": re.compile(r"to\s+(\w+)", re.IGNORECASE),
+    },
+    "it": {
+        "from": re.compile(r"da\s+(\w+)", re.IGNORECASE),
+        "to": re.compile(r"\ba\s+(\w+)", re.IGNORECASE),
+    },
+}
+
 _RE_TIME = re.compile(r"([0-2]?\d[:.]\d{2})")
-_RE_FROM = re.compile(r"von\s+(\w+)", re.IGNORECASE)
-_RE_TO = re.compile(r"nach\s+(\w+)", re.IGNORECASE)
 _RE_TIME_TOKEN = re.compile(r"[0-2]?\d[:.]\d{2}")
 
-def _get_nlp() -> spacy.Language:
-    global _nlp
-    if _nlp is None:
+def _detect_language(text: str) -> str:
+    try:
+        return detect(text)
+    except Exception:
+        return "en"
+
+def _get_nlp(lang: str) -> spacy.Language:
+    if lang in _nlp_cache:
+        return _nlp_cache[lang]
+    model = LANG_MODELS.get(lang)
+    if model:
         try:
-            _nlp = spacy.load("de_core_news_sm")
+            nlp = spacy.load(model)
         except OSError:
-            _nlp = spacy.blank("de")
-    return _nlp
+            nlp = spacy.blank(lang)
+    else:
+        nlp = spacy.blank(lang)
+    _nlp_cache[lang] = nlp
+    return nlp
 
 def parse_query(text: str) -> Dict[str, Optional[str]]:
     """Extract stops and time from a natural language query."""
-    nlp = _get_nlp()
-    logger.debug("Parsing text: %s", text)
+    lang = _detect_language(text)
+    nlp = _get_nlp(lang)
+    regex = LANG_REGEX.get(lang, LANG_REGEX.get("en"))
+
+    logger.debug("Parsing text (%s): %s", lang, text)
     doc = nlp(text)
     stops = [t.text for t in doc if t.pos_ == "PROPN"]
 
     # Filter out tokens that look like a time expression
     stops = [s for s in stops if not _RE_TIME_TOKEN.fullmatch(s)]
 
-    m_from = _RE_FROM.search(text)
-    m_to = _RE_TO.search(text)
+    m_from = regex["from"].search(text)
+    m_to = regex["to"].search(text)
 
     if m_from:
         from_stop = m_from.group(1)

--- a/tests/test_nlp_parser.py
+++ b/tests/test_nlp_parser.py
@@ -11,3 +11,17 @@ def test_parse_query_basic():
     assert result.get("to_stop") == "Meran"
     assert result.get("time") == "14:30"
 
+def test_parse_query_english():
+    text = "How do I get from Bolzano to Merano at 14:30?"
+    result = nlp_parser.parse_query(text)
+    assert result.get("from_stop") == "Bolzano"
+    assert result.get("to_stop") == "Merano"
+    assert result.get("time") == "14:30"
+
+def test_parse_query_italian():
+    text = "Come arrivo da Bolzano a Merano alle 14:30?"
+    result = nlp_parser.parse_query(text)
+    assert result.get("from_stop") == "Bolzano"
+    assert result.get("to_stop") == "Merano"
+    assert result.get("time") == "14:30"
+


### PR DESCRIPTION
## Summary
- add `langdetect` requirement for language detection
- update `nlp_parser` to auto-detect language and load corresponding spaCy models
- support German, English and Italian queries via regex maps
- extend tests for English and Italian

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686545a224b88321a63d923ca57ec445