### PR TITLE
Implement language-aware requests

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -69,8 +69,9 @@ def run_departures(stop: str, output_format: str = "text", debug: bool = False) 
         ``"text"`` for a short summary, ``"json"`` for the raw API response.
     """
     logger.info("Haltestelle '%s' wird ermittelt...", stop)
+    lang = nlp_parser.detect_language(stop)
     try:
-        result = efa_api.dm_request(stop)
+        result = efa_api.dm_request(stop, lang=lang)
     except Exception as exc:
         logger.error("Fehler bei der Abfrage: %s", exc)
         return
@@ -90,8 +91,9 @@ def run_departures(stop: str, output_format: str = "text", debug: bool = False) 
 def run_stop_finder(query: str, output_format: str = "text", debug: bool = False) -> None:
     """Query the stop finder and print the result."""
     logger.info("Searching stops...")
+    lang = nlp_parser.detect_language(query)
     try:
-        result = efa_api.stopfinder_request(query)
+        result = efa_api.stopfinder_request(query, lang=lang)
     except Exception as exc:
         logger.error("Error during request: %s", exc)
         return

--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -4,6 +4,7 @@ import logging
 import requests
 
 from .logging_utils import setup_logging
+from . import nlp_parser
 
 logger = logging.getLogger(__name__)
 setup_logging()
@@ -11,13 +12,15 @@ setup_logging()
 BASE_URL = os.environ.get("EFA_BASE_URL", "https://efa.sta.bz.it/apb")
 
 
-def get_stop_code(query: str) -> str:
+def get_stop_code(query: str, lang: Optional[str] = None) -> str:
     """Resolve a stop name to its stateless identifier using a StopFinder request.
 
     The returned code can be used directly in subsequent trip or departure
     requests. If the lookup fails, the original query string is returned
     unchanged.
     """
+    if lang is None:
+        lang = nlp_parser.detect_language(query)
     url = f"{BASE_URL}/XML_STOPFINDER_REQUEST"
     params = {
         "odvSugMacro": "true",
@@ -26,6 +29,8 @@ def get_stop_code(query: str) -> str:
         "locationServerActive": 1,
         "outputEncoding": "UTF-8",
     }
+    if lang in ("de", "it"):
+        params["language"] = lang
 
     logger.debug("Requesting stop code for '%s'", query)
     try:
@@ -97,12 +102,13 @@ def search_efa(params: Dict[str, Any]) -> Dict[str, Any]:
 
     logger.info("Searching trip: %s", params)
 
+    lang = params.get("lang")
     from_stop = params.get("from_stop")
     if from_stop:
-        from_stop = get_stop_code(from_stop)
+        from_stop = get_stop_code(from_stop, lang)
     to_stop = params.get("to_stop")
     if to_stop:
-        to_stop = get_stop_code(to_stop)
+        to_stop = get_stop_code(to_stop, lang)
 
     efa_params = {
         "name_origin": from_stop,
@@ -115,6 +121,8 @@ def search_efa(params: Dict[str, Any]) -> Dict[str, Any]:
         "odvMacro": "true",
         "outputEncoding": "UTF-8",
     }
+    if lang in ("de", "it"):
+        efa_params["language"] = lang
 
     time = params.get("time")
     if time:
@@ -132,13 +140,14 @@ def search_efa(params: Dict[str, Any]) -> Dict[str, Any]:
         return {"text": response.text}
 
 
-def dm_request(stop_name: str, limit: int = 10) -> Dict[str, Any]:
+def dm_request(stop_name: str, limit: int = 10, lang: Optional[str] = None) -> Dict[str, Any]:
     """Query the departure monitor (DM) endpoint for a specific stop."""
     url = f"{BASE_URL}/XML_DM_REQUEST"
     logger.info("Requesting departures for '%s'", stop_name)
-    stop_name = get_stop_code(stop_name)
+    if lang is None:
+        lang = nlp_parser.detect_language(stop_name)
+    stop_name = get_stop_code(stop_name, lang)
     params = {
-        "language": "de",
         "type_dm": "stop",
         "name_dm": stop_name,
         "mode": "direct",
@@ -148,6 +157,8 @@ def dm_request(stop_name: str, limit: int = 10) -> Dict[str, Any]:
         "odvMacro": "true",
         "outputEncoding": "UTF-8",
     }
+    if lang in ("de", "it"):
+        params["language"] = lang
 
     logger.debug("DM request params: %s", params)
     response = requests.get(url, params=params, timeout=10)
@@ -161,9 +172,11 @@ def dm_request(stop_name: str, limit: int = 10) -> Dict[str, Any]:
         return {"text": response.text}
 
 
-def stopfinder_request(query: str) -> Dict[str, Any]:
+def stopfinder_request(query: str, lang: Optional[str] = None) -> Dict[str, Any]:
     """Return stop suggestions for the given search string."""
     url = f"{BASE_URL}/XML_STOPFINDER_REQUEST"
+    if lang is None:
+        lang = nlp_parser.detect_language(query)
     params = {
         "odvSugMacro": "true",
         "name_sf": query,
@@ -171,6 +184,8 @@ def stopfinder_request(query: str) -> Dict[str, Any]:
         "locationServerActive": 1,
         "outputEncoding": "UTF-8",
     }
+    if lang in ("de", "it"):
+        params["language"] = lang
     logger.info("Stop finder for query '%s'", query)
     logger.debug("StopFinder params: %s", params)
     response = requests.get(url, params=params, timeout=10)

--- a/src/main.py
+++ b/src/main.py
@@ -49,7 +49,8 @@ def departures(req: DMRequest, format: str = "json"):
     logger.info("/departures stop='%s' limit=%s", req.stop, req.limit)
     if not req.stop:
         raise HTTPException(status_code=400, detail="Missing stop name")
-    result = efa_api.dm_request(req.stop, req.limit)
+    lang = nlp_parser.detect_language(req.stop)
+    result = efa_api.dm_request(req.stop, req.limit, lang)
     logger.debug("/departures result: %s", result)
     if format == "text":
         return PlainTextResponse(format_departures_result(result))
@@ -62,7 +63,8 @@ def stops(req: StopFinderRequest, format: str = "json"):
     logger.info("/stops query='%s'", req.query)
     if not req.query:
         raise HTTPException(status_code=400, detail="Missing query")
-    result = efa_api.stopfinder_request(req.query)
+    lang = nlp_parser.detect_language(req.query)
+    result = efa_api.stopfinder_request(req.query, lang)
     logger.debug("/stops result: %s", result)
     if format == "text":
         return PlainTextResponse(format_stops_result(result))

--- a/src/nlp_parser.py
+++ b/src/nlp_parser.py
@@ -43,6 +43,11 @@ def _detect_language(text: str) -> str:
     except Exception:
         return "en"
 
+
+def detect_language(text: str) -> str:
+    """Public wrapper to detect the language of ``text``."""
+    return _detect_language(text)
+
 def _get_nlp(lang: str) -> spacy.Language:
     if lang in _nlp_cache:
         return _nlp_cache[lang]
@@ -108,6 +113,7 @@ def parse_query(text: str) -> Dict[str, Optional[str]]:
         result["to_stop"] = to_stop
     if time:
         result["time"] = time
+    result["lang"] = lang
     logger.debug("Parsed parameters: %s", result)
     return result
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -46,15 +46,16 @@ def test_search_endpoint_legs(mock_parse_query, mock_search_efa, mock_format):
     mock_format.assert_called_once_with({'dummy': True}, legs_only=True)
 
 
+@patch('src.main.nlp_parser.detect_language', return_value='de')
 @patch('src.main.efa_api.dm_request')
-def test_departures_endpoint(mock_dm_request):
+def test_departures_endpoint(mock_dm_request, mock_detect):
     expected = {'dm': 'ok'}
     mock_dm_request.return_value = expected
     client = TestClient(app)
     response = client.post('/departures', json={'stop': 'Bozen', 'limit': 5})
     assert response.status_code == 200
     assert response.json() == expected
-    mock_dm_request.assert_called_once_with('Bozen', 5)
+    mock_dm_request.assert_called_once_with('Bozen', 5, 'de')
 
 
 @patch('src.main.format_departures_result', return_value='dep')
@@ -68,15 +69,16 @@ def test_departures_endpoint_text(mock_dm_request, mock_format):
     mock_format.assert_called_once_with({'ok': True})
 
 
+@patch('src.main.nlp_parser.detect_language', return_value='de')
 @patch('src.main.efa_api.stopfinder_request')
-def test_stops_endpoint(mock_stopfinder_request):
+def test_stops_endpoint(mock_stopfinder_request, mock_detect):
     expected = {'stops': []}
     mock_stopfinder_request.return_value = expected
     client = TestClient(app)
     response = client.post('/stops', json={'query': 'Brixen'})
     assert response.status_code == 200
     assert response.json() == expected
-    mock_stopfinder_request.assert_called_once_with('Brixen')
+    mock_stopfinder_request.assert_called_once_with('Brixen', 'de')
 
 
 @patch('src.main.format_stops_result', return_value='stops')


### PR DESCRIPTION
## Summary
- expose `detect_language` helper in NLP parser
- include detected language in parsing results
- forward `language` parameter in EFA API calls when language is German or Italian
- detect language for `/departures` and `/stops` endpoints and CLI commands
- update tests for new parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68662b1f04808321a35edf739ee0c3e8