### PR TITLE
Improve parser and unify API

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ The service exposes three POST endpoints:
 - `/stops` – return stop name suggestions
 
 
-After the server is running, you can query it with a POST request. The `/search`
-endpoint returns a short plain‑text summary of the trip legs. Append
-`?format=json` if you need the raw JSON response. The other endpoints return
-JSON by default and accept `?format=text` for a short summary:
+After the server is running, you can query it with a POST request. All endpoints
+return JSON by default. The `/search` endpoint instead returns a plain‑text list
+of the connection legs. Append `?format=json` if you need the raw JSON. The
+other endpoints support `?format=text` for plain‑text output:
 
 ```bash
 # Trip request (plain text)

--- a/src/main.py
+++ b/src/main.py
@@ -29,7 +29,7 @@ class StopFinderRequest(BaseModel):
     query: str
 
 @app.post("/search")
-def search(req: SearchRequest, format: str = "legs"):
+def search(req: SearchRequest, format: str | None = None):
     logger.info("/search text='%s'", req.text)
     params = nlp_parser.parse_query(req.text)
     if not params:
@@ -40,6 +40,7 @@ def search(req: SearchRequest, format: str = "legs"):
         return result
     if format == "text":
         return PlainTextResponse(format_search_result(result, legs_only=False))
+    # default plain-text response lists the individual legs
     return PlainTextResponse(format_search_result(result, legs_only=True))
 
 

--- a/src/nlp_parser.py
+++ b/src/nlp_parser.py
@@ -35,6 +35,7 @@ LANG_REGEX = {
 }
 
 _RE_TIME = re.compile(r"([0-2]?\d[:.]\d{2})")
+_RE_TIME_ALT = re.compile(r"(?:um\s*)?(\d{1,2})\s*uhr(?:\s*(\d{1,2}))?", re.IGNORECASE)
 _RE_TIME_TOKEN = re.compile(r"[0-2]?\d[:.]\d{2}")
 
 def _detect_language(text: str) -> str:
@@ -104,7 +105,21 @@ def parse_query(text: str) -> Dict[str, Optional[str]]:
         to_stop = None
 
     time_match = _RE_TIME.search(text)
-    time = time_match.group(1).replace('.', ':') if time_match else None
+    if time_match:
+        time = time_match.group(1).replace('.', ':')
+    else:
+        alt_match = _RE_TIME_ALT.search(text)
+        if alt_match:
+            hour = alt_match.group(1)
+            minute = alt_match.group(2) or "00"
+            try:
+                h = int(hour)
+                m = int(minute)
+                time = f"{h:02d}:{m:02d}"
+            except ValueError:
+                time = None
+        else:
+            time = None
 
     result: Dict[str, Optional[str]] = {}
     if from_stop:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -36,7 +36,7 @@ def test_search_endpoint_text(mock_parse_query, mock_search_efa, mock_format):
 @patch('src.main.format_search_result', return_value='legs')
 @patch('src.main.efa_api.search_efa')
 @patch('src.main.nlp_parser.parse_query')
-def test_search_endpoint_legs(mock_parse_query, mock_search_efa, mock_format):
+def test_search_endpoint_default(mock_parse_query, mock_search_efa, mock_format):
     mock_parse_query.return_value = {'from_stop': 'A', 'to_stop': 'B'}
     mock_search_efa.return_value = {'dummy': True}
     client = TestClient(app)


### PR DESCRIPTION
## Summary
- improve time parsing to accept phrases like `14 Uhr 30`
- `/search` now returns a plain-text list of legs by default
- remove `format=legs` parameter and update documentation
- update tests for new default

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686635a2ad54832190710b37d1dbf4e4