### PR TITLE
Add optional ChatGPT query parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ All requests automatically enable the EFA location server via
 `locationServerActive=1`. Trip and departure monitor queries also send
 `odvMacro=true`. Starting with version 0.2 all requests specify
 `outputEncoding=UTF-8` to ensure UTF‑8 encoded responses.
+
+### ChatGPT query parsing
+
+Set the `OPENAI_API_KEY` environment variable to enable parsing of search
+queries via OpenAI's ChatGPT API. Queries will be sent to OpenAI's servers,
+which requires internet access and may incur usage fees. Use the `--chatgpt`
+flag in the CLI or pass `chatgpt=true` to the `/search` endpoint:
+
+```bash
+OPENAI_API_KEY=sk-... python -m src.cli search "Bozen nach Meran" --chatgpt
+
+# or for the API
+OPENAI_API_KEY=sk-... uvicorn src.main:app --host 0.0.0.0 --reload
+# POST /search?chatgpt=true
+```
 ## API endpoints
 
 The service exposes three POST endpoints:

--- a/src/chatgpt_helper.py
+++ b/src/chatgpt_helper.py
@@ -1,0 +1,48 @@
+import os
+import json
+import logging
+import requests
+
+logger = logging.getLogger(__name__)
+
+API_URL = "https://api.openai.com/v1/chat/completions"
+
+
+def parse_query_chatgpt(text: str) -> dict:
+    """Parse the query text via the OpenAI ChatGPT API."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": "gpt-3.5-turbo",
+        "temperature": 0,
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "Extract origin, destination and time from the text. "
+                    "Return JSON with keys 'from_stop', 'to_stop' and 'time'."
+                ),
+            },
+            {"role": "user", "content": text},
+        ],
+    }
+
+    logger.debug("Sending query to ChatGPT: %s", text)
+    response = requests.post(API_URL, headers=headers, json=payload, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+    content = data["choices"][0]["message"]["content"].strip()
+    try:
+        parsed = json.loads(content)
+        logger.debug("ChatGPT parsed query: %s", parsed)
+        return parsed
+    except json.JSONDecodeError:
+        logger.warning("Unexpected ChatGPT response: %s", content)
+        return {}
+

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 
-from . import nlp_parser, efa_api
+from . import nlp_parser, efa_api, chatgpt_helper
 from .logging_utils import setup_logging
 from .summaries import (
     format_search_result,
@@ -12,7 +12,7 @@ from .summaries import (
 logger = logging.getLogger(__name__)
 
 
-def run_search(query: str, output_format: str = "legs", debug: bool = False) -> None:
+def run_search(query: str, output_format: str = "legs", debug: bool = False, use_chatgpt: bool = False) -> None:
     """Run a search for the given natural language query.
 
     Parameters
@@ -23,9 +23,14 @@ def run_search(query: str, output_format: str = "legs", debug: bool = False) -> 
         ``"legs"`` prints only the individual trip legs,
         ``"text"`` shows a longer summary,
         ``"json"`` dumps the raw API response.
+    use_chatgpt: bool, optional
+        If set, the query is parsed via the OpenAI API.
     """
     logger.info("Searching for stops...")
-    params = nlp_parser.parse_query(query)
+    if use_chatgpt:
+        params = chatgpt_helper.parse_query_chatgpt(query)
+    else:
+        params = nlp_parser.parse_query(query)
 
     if not params:
         logger.warning("No parameters extracted from the query.")
@@ -118,13 +123,18 @@ if __name__ == "__main__":
         default="legs",
         help="Output format",
     )
+    parser.add_argument(
+        "--chatgpt",
+        action="store_true",
+        help="Use ChatGPT for query parsing",
+    )
 
     args = parser.parse_args()
     setup_logging(args.debug)
 
     argument = " ".join(args.text)
     if args.command == "search":
-        run_search(argument, args.format, debug=args.debug)
+        run_search(argument, args.format, debug=args.debug, use_chatgpt=args.chatgpt)
     elif args.command == "departures":
         run_departures(argument, args.format, debug=args.debug)
     elif args.command == "stops":

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,7 @@ from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 import logging
 
-from . import nlp_parser, efa_api
+from . import nlp_parser, efa_api, chatgpt_helper
 from .summaries import (
     format_search_result,
     format_departures_result,
@@ -29,9 +29,12 @@ class StopFinderRequest(BaseModel):
     query: str
 
 @app.post("/search")
-def search(req: SearchRequest, format: str | None = None):
+def search(req: SearchRequest, format: str | None = None, chatgpt: bool = False):
     logger.info("/search text='%s'", req.text)
-    params = nlp_parser.parse_query(req.text)
+    if chatgpt:
+        params = chatgpt_helper.parse_query_chatgpt(req.text)
+    else:
+        params = nlp_parser.parse_query(req.text)
     if not params:
         raise HTTPException(status_code=400, detail="No parameters extracted")
     result = efa_api.search_efa(params)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,3 +32,16 @@ def test_run_search_legs(mock_parse, mock_search, mock_format, capsys):
     captured = capsys.readouterr()
     assert captured.out.strip() == 'legs'
     mock_format.assert_called_once_with({'ok': True}, legs_only=True)
+
+
+@patch('src.cli.format_search_result', return_value='legs')
+@patch('src.cli.efa_api.search_efa', return_value={'ok': True})
+@patch('src.cli.nlp_parser.parse_query')
+@patch('src.cli.chatgpt_helper.parse_query_chatgpt', return_value={'from_stop': 'A', 'to_stop': 'B'})
+def test_run_search_chatgpt(mock_chatgpt, mock_parse, mock_search, mock_format, capsys):
+    cli.run_search('foo', output_format='legs', use_chatgpt=True)
+    captured = capsys.readouterr()
+    assert captured.out.strip() == 'legs'
+    mock_chatgpt.assert_called_once_with('foo')
+    mock_parse.assert_not_called()
+    mock_format.assert_called_once_with({'ok': True}, legs_only=True)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -46,6 +46,22 @@ def test_search_endpoint_default(mock_parse_query, mock_search_efa, mock_format)
     mock_format.assert_called_once_with({'dummy': True}, legs_only=True)
 
 
+@patch('src.main.format_search_result', return_value='legs')
+@patch('src.main.efa_api.search_efa')
+@patch('src.main.nlp_parser.parse_query')
+@patch('src.main.chatgpt_helper.parse_query_chatgpt')
+def test_search_endpoint_chatgpt(mock_chatgpt, mock_parse_query, mock_search_efa, mock_format):
+    mock_chatgpt.return_value = {'from_stop': 'A', 'to_stop': 'B'}
+    mock_search_efa.return_value = {'dummy': True}
+    client = TestClient(app)
+    response = client.post('/search?chatgpt=true', json={'text': 'foo'})
+    assert response.status_code == 200
+    assert response.text == 'legs'
+    mock_chatgpt.assert_called_once_with('foo')
+    mock_parse_query.assert_not_called()
+    mock_format.assert_called_once_with({'dummy': True}, legs_only=True)
+
+
 @patch('src.main.nlp_parser.detect_language', return_value='de')
 @patch('src.main.efa_api.dm_request')
 def test_departures_endpoint(mock_dm_request, mock_detect):


### PR DESCRIPTION
## Summary
- provide OpenAI helper for query parsing
- allow using ChatGPT via `--chatgpt` flag or `chatgpt=true` query parameter
- document enabling ChatGPT with `OPENAI_API_KEY`
- clarify README note about network usage and potential costs
- add unit tests for the new ChatGPT parsing paths

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686639c9717083219635b4240b8cd6c9