### PR TITLE
Enable ChatGPT query parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ Set the `OPENAI_API_KEY` environment variable to enable reformatting of the
 plain‑text summaries via OpenAI's ChatGPT API. Requests will be sent to
 OpenAI's servers, which requires internet access and may incur usage fees.
 Use the `--chatgpt` flag in the CLI or pass `chatgpt=true` to any endpoint that
-returns plain text:
+returns plain text. When enabled for the `search` command or `/search` endpoint
+the query is first parsed via ChatGPT. The CLI falls back to the built‑in
+parser if this step fails:
 
 ```bash
 OPENAI_API_KEY=sk-... python -m src.cli search "Bozen nach Meran" --chatgpt

--- a/src/cli.py
+++ b/src/cli.py
@@ -27,7 +27,16 @@ def run_search(query: str, output_format: str = "legs", debug: bool = False, use
         If set, the plain-text summary is reformatted via the OpenAI API.
     """
     logger.info("Searching for stops...")
-    params = nlp_parser.parse_query(query)
+    params = {}
+    if use_chatgpt:
+        try:
+            params = chatgpt_helper.parse_query_chatgpt(query)
+        except Exception as exc:
+            logger.error("ChatGPT parsing failed: %s", exc)
+            params = {}
+
+    if not params:
+        params = nlp_parser.parse_query(query)
 
     if not params:
         logger.warning("No parameters extracted from the query.")

--- a/src/main.py
+++ b/src/main.py
@@ -32,7 +32,10 @@ class StopFinderRequest(BaseModel):
 @app.post("/search")
 def search(req: SearchRequest, format: Optional[str] = None, chatgpt: bool = False):
     logger.info("/search text='%s'", req.text)
-    params = nlp_parser.parse_query(req.text)
+    if chatgpt:
+        params = chatgpt_helper.parse_query_chatgpt(req.text)
+    else:
+        params = nlp_parser.parse_query(req.text)
     if not params:
         raise HTTPException(status_code=400, detail="No parameters extracted")
     result = efa_api.search_efa(params)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,10 +37,28 @@ def test_run_search_legs(mock_parse, mock_search, mock_format, capsys):
 @patch('src.cli.chatgpt_helper.reformat_summary', return_value='better')
 @patch('src.cli.format_search_result', return_value='legs')
 @patch('src.cli.efa_api.search_efa', return_value={'ok': True})
-@patch('src.cli.nlp_parser.parse_query', return_value={'from_stop': 'A', 'to_stop': 'B'})
-def test_run_search_chatgpt(mock_parse, mock_search, mock_format, mock_reformat, capsys):
+@patch('src.cli.nlp_parser.parse_query')
+@patch('src.cli.chatgpt_helper.parse_query_chatgpt', return_value={'from_stop': 'A', 'to_stop': 'B'})
+def test_run_search_chatgpt(mock_parse_gpt, mock_parse, mock_search, mock_format, mock_reformat, capsys):
     cli.run_search('foo', output_format='legs', use_chatgpt=True)
     captured = capsys.readouterr()
     assert captured.out.strip() == 'better'
+    mock_parse_gpt.assert_called_once_with('foo')
+    mock_parse.assert_not_called()
+    mock_reformat.assert_called_once_with('legs')
+    mock_format.assert_called_once_with({'ok': True}, legs_only=True)
+
+
+@patch('src.cli.chatgpt_helper.reformat_summary', return_value='better')
+@patch('src.cli.format_search_result', return_value='legs')
+@patch('src.cli.efa_api.search_efa', return_value={'ok': True})
+@patch('src.cli.nlp_parser.parse_query', return_value={'from_stop': 'A', 'to_stop': 'B'})
+@patch('src.cli.chatgpt_helper.parse_query_chatgpt', return_value={})
+def test_run_search_chatgpt_fallback(mock_parse_gpt, mock_parse, mock_search, mock_format, mock_reformat, capsys):
+    cli.run_search('foo', output_format='legs', use_chatgpt=True)
+    captured = capsys.readouterr()
+    assert captured.out.strip() == 'better'
+    mock_parse_gpt.assert_called_once_with('foo')
+    mock_parse.assert_called_once_with('foo')
     mock_reformat.assert_called_once_with('legs')
     mock_format.assert_called_once_with({'ok': True}, legs_only=True)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -50,16 +50,29 @@ def test_search_endpoint_default(mock_parse_query, mock_search_efa, mock_format)
 @patch('src.main.format_search_result', return_value='legs')
 @patch('src.main.efa_api.search_efa')
 @patch('src.main.nlp_parser.parse_query')
-def test_search_endpoint_chatgpt(mock_parse_query, mock_search_efa, mock_format, mock_reformat):
-    mock_parse_query.return_value = {'from_stop': 'A', 'to_stop': 'B'}
+@patch('src.main.chatgpt_helper.parse_query_chatgpt', return_value={'from_stop': 'A', 'to_stop': 'B'})
+def test_search_endpoint_chatgpt(mock_parse_gpt, mock_parse_query, mock_search_efa, mock_format, mock_reformat):
     mock_search_efa.return_value = {'dummy': True}
     client = TestClient(app)
     response = client.post('/search?chatgpt=true', json={'text': 'foo'})
     assert response.status_code == 200
     assert response.text == 'better'
-    mock_parse_query.assert_called_once_with('foo')
+    mock_parse_gpt.assert_called_once_with('foo')
+    mock_parse_query.assert_not_called()
     mock_format.assert_called_once_with({'dummy': True}, legs_only=True)
     mock_reformat.assert_called_once_with('legs')
+
+
+@patch('src.main.efa_api.search_efa')
+@patch('src.main.nlp_parser.parse_query')
+@patch('src.main.chatgpt_helper.parse_query_chatgpt', return_value={})
+def test_search_endpoint_chatgpt_bad_parse(mock_parse_gpt, mock_parse_query, mock_search_efa):
+    client = TestClient(app)
+    response = client.post('/search?chatgpt=true', json={'text': 'foo'})
+    assert response.status_code == 400
+    mock_parse_gpt.assert_called_once_with('foo')
+    mock_parse_query.assert_not_called()
+    mock_search_efa.assert_not_called()
 
 
 @patch('src.main.nlp_parser.detect_language', return_value='de')


### PR DESCRIPTION
## Summary
- use ChatGPT to parse search queries in the CLI (fallback to NLP parser)
- support ChatGPT parsing for the `/search` endpoint
- update README docs for the new behaviour
- add unit tests for CLI/API ChatGPT parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686640ebdd8c8321946020052c07f102