### PR TITLE
Add Telegram bot script

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,20 @@ Enable verbose logging for both the CLI and the server by passing
 python -m src.cli search "Bozen nach Meran" --debug
 ```
 
+## Telegram bot
+
+A small example bot in `src/telegram_bot.py` forwards incoming Telegram messages to the running API and replies with the plain text result.
+
+Start the bot after setting your token:
+
+```bash
+export TELEGRAM_TOKEN=your_token
+python -m src.telegram_bot
+```
+
+Set `API_URL` if the API is reachable under a different address.
+
+
 
 ## Testing
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ uvicorn
 pytest
 httpx<0.25
 langdetect
+python-telegram-bot>=20

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -1,0 +1,30 @@
+import os
+import requests
+from telegram.ext import Application, MessageHandler, filters
+
+API_URL = os.getenv("API_URL", "http://localhost:8000")
+BOT_TOKEN = os.getenv("TELEGRAM_TOKEN")
+
+async def handle_text(update, context):
+    text = update.message.text
+    try:
+        resp = requests.post(f"{API_URL}/search?format=text", json={"text": text})
+        if resp.status_code == 200:
+            await update.message.reply_text(resp.text)
+        else:
+            await update.message.reply_text(f"Error: {resp.text}")
+    except Exception as exc:
+        await update.message.reply_text(f"Request failed: {exc}")
+
+
+def main() -> None:
+    if not BOT_TOKEN:
+        raise RuntimeError("TELEGRAM_TOKEN environment variable not set")
+
+    application = Application.builder().token(BOT_TOKEN).build()
+    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_text))
+    application.run_polling()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add example `telegram_bot.py` script for forwarding Telegram messages to the API
- document usage in README
- require `python-telegram-bot`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68664017004c832184e0e09a2e934594