### PR TITLE
Add Python version check for Telegram bot

### DIFF
--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -1,4 +1,9 @@
 import os
+import sys
+
+if sys.version_info < (3, 8):
+    raise RuntimeError("telegram_bot.py requires Python 3.8 or newer")
+
 import requests
 from telegram.ext import Application, MessageHandler, filters
 


### PR DESCRIPTION
## Summary
- guard against running `src/telegram_bot.py` on Python versions older than 3.8

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68664e75f01c8321ac8006ad1e933360