### PR TITLE
Pin spacy version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 python -m spacy download de_core_news_sm  # optional
 ```
+spaCy is pinned to versions below 3.8 for compatibility.
 
 ## Running the API
 Start the server with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 requests
-spacy
+spacy<3.8
 pydantic
 uvicorn
 pytest


### PR DESCRIPTION
## Summary
- pin spacy below 3.8 in requirements
- document pinned version in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686784846b3083218bb18b2e3d31534d