### PR TITLE
Add API URL option for Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,11 @@ OPENAI_API_KEY=sk-... uvicorn src.main:app --host 0.0.0.0 --reload
 Forward messages to the API using the example bot:
 ```bash
 export TELEGRAM_TOKEN=your_token
-python -m src.telegram_bot
+python -m src.telegram_bot --api-url http://localhost:8000 --chatgpt
 ```
-Set `API_URL` if the API runs on a different address.
+Use `--api-url` to specify the address of the running API. Pass `--chatgpt`
+for nicer ChatGPT summaries. Options default to the `API_URL` environment
+variable and plain text output if unset.
 
 ## Testing
 ```bash

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import argparse
 
 if sys.version_info < (3, 8):
     raise RuntimeError("telegram_bot.py requires Python 3.8 or newer")
@@ -9,11 +10,30 @@ from telegram.ext import Application, MessageHandler, filters
 
 API_URL = os.getenv("API_URL", "http://localhost:8000")
 BOT_TOKEN = os.getenv("TELEGRAM_TOKEN")
+USE_CHATGPT = False
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser(description="Telegram interface for suedtirolmobilAI")
+    parser.add_argument(
+        "--api-url",
+        default=API_URL,
+        help="Base URL of the API server",
+    )
+    parser.add_argument(
+        "--chatgpt",
+        action="store_true",
+        help="Use ChatGPT summaries via the API",
+    )
+    return parser.parse_args(args)
 
 async def handle_text(update, context):
     text = update.message.text
     try:
-        resp = requests.post(f"{API_URL}/search?format=text", json={"text": text})
+        url = f"{API_URL}/search?format=text"
+        if USE_CHATGPT:
+            url += "&chatgpt=true"
+        resp = requests.post(url, json={"text": text})
         if resp.status_code == 200:
             await update.message.reply_text(resp.text)
         else:
@@ -23,8 +43,14 @@ async def handle_text(update, context):
 
 
 def main() -> None:
+    global API_URL, USE_CHATGPT
+
     if not BOT_TOKEN:
         raise RuntimeError("TELEGRAM_TOKEN environment variable not set")
+
+    args = parse_args()
+    API_URL = args.api_url
+    USE_CHATGPT = args.chatgpt
 
     application = Application.builder().token(BOT_TOKEN).build()
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_text))

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from src import telegram_bot
+
+
+def test_parse_args_default():
+    args = telegram_bot.parse_args([])
+    assert args.api_url == "http://localhost:8000"
+    assert args.chatgpt is False
+
+
+def test_parse_args_override():
+    args = telegram_bot.parse_args(["--api-url", "http://1.2.3.4:8000"])
+    assert args.api_url == "http://1.2.3.4:8000"
+
+
+def test_parse_args_chatgpt():
+    args = telegram_bot.parse_args(["--chatgpt"])
+    assert args.chatgpt is True


### PR DESCRIPTION
## Summary
- add argparse-based `--api-url` option to `src.telegram_bot`
- mention the option in the README
- test argument parsing for the Telegram bot
- add `--chatgpt` support to Telegram bot

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867872516d8832182a1fbe9d849855d