### PR TITLE
Add dynamic command handling to Telegram bot

### DIFF
--- a/src/chatgpt_helper.py
+++ b/src/chatgpt_helper.py
@@ -47,6 +47,54 @@ def parse_query_chatgpt(text: str) -> dict:
         return {}
 
 
+def classify_query_chatgpt(text: str) -> dict:
+    """Classify the user text and extract request parameters via ChatGPT.
+
+    The function returns a dictionary with at least the key ``endpoint`` which
+    is one of ``"search"``, ``"departures"`` or ``"stops"``.  Additional keys
+    provide the extracted parameters for the chosen endpoint.
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": "gpt-3.5-turbo",
+        "temperature": 0,
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "Decide which public transport API endpoint is best suited "
+                    "for the user request. Choose between 'search', 'departures' "
+                    "and 'stops'. Return JSON with an 'endpoint' key. If the "
+                    "endpoint is 'search', also return 'from_stop', 'to_stop' "
+                    "and optionally 'time'. If it is 'departures', return "
+                    "'stop'. If it is 'stops', return 'query'."
+                ),
+            },
+            {"role": "user", "content": text},
+        ],
+    }
+
+    logger.debug("Classifying query via ChatGPT: %s", text)
+    response = requests.post(API_URL, headers=headers, json=payload, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+    content = data["choices"][0]["message"]["content"].strip()
+    try:
+        parsed = json.loads(content)
+        logger.debug("ChatGPT classified query: %s", parsed)
+        return parsed
+    except json.JSONDecodeError:
+        logger.warning("Unexpected ChatGPT response: %s", content)
+        return {}
+
+
 def reformat_summary(text: str) -> str:
     """Return a ChatGPT reformatted version of ``text``.
 

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -6,7 +6,10 @@ if sys.version_info < (3, 8):
     raise RuntimeError("telegram_bot.py requires Python 3.8 or newer")
 
 import requests
-from telegram.ext import Application, MessageHandler, filters
+from telegram import ReplyKeyboardMarkup
+from telegram.ext import Application, MessageHandler, CommandHandler, filters
+
+from . import chatgpt_helper
 
 API_URL = os.getenv("API_URL", "http://localhost:8000")
 BOT_TOKEN = os.getenv("TELEGRAM_TOKEN")
@@ -22,9 +25,84 @@ def parse_args(args=None):
     return parser.parse_args(args)
 
 async def handle_text(update, context):
+    """Handle free text by classifying the request via ChatGPT."""
     text = update.message.text
     try:
-        resp = requests.post(f"{API_URL}/search?format=text", json={"text": text})
+        info = chatgpt_helper.classify_query_chatgpt(text)
+    except Exception as exc:
+        info = {}
+
+    endpoint = (info.get("endpoint") or "search").lower()
+    if endpoint == "departures":
+        stop = info.get("stop") or text
+        url = f"{API_URL}/departures?format=text&chatgpt=true"
+        payload = {"stop": stop}
+    elif endpoint == "stops":
+        query = info.get("query") or text
+        url = f"{API_URL}/stops?format=text&chatgpt=true"
+        payload = {"query": query}
+    else:
+        url = f"{API_URL}/search?chatgpt=true"
+        payload = {"text": text}
+
+    try:
+        resp = requests.post(url, json=payload)
+        if resp.status_code == 200:
+            await update.message.reply_text(resp.text)
+        else:
+            await update.message.reply_text(f"Error: {resp.text}")
+    except Exception as exc:
+        await update.message.reply_text(f"Request failed: {exc}")
+
+
+async def cmd_start(update, context):
+    """Send a welcome message and show the command keyboard."""
+    keyboard = [["/search", "/departures", "/stops"]]
+    markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
+    await update.message.reply_text(
+        "Welcome! Send me a request or choose a command.", reply_markup=markup
+    )
+
+
+async def cmd_search(update, context):
+    query = update.message.text.partition(" ")[2].strip()
+    if not query:
+        await update.message.reply_text("Please provide a query after /search")
+        return
+    try:
+        resp = requests.post(f"{API_URL}/search?chatgpt=true", json={"text": query})
+        if resp.status_code == 200:
+            await update.message.reply_text(resp.text)
+        else:
+            await update.message.reply_text(f"Error: {resp.text}")
+    except Exception as exc:
+        await update.message.reply_text(f"Request failed: {exc}")
+
+
+async def cmd_departures(update, context):
+    stop = update.message.text.partition(" ")[2].strip()
+    if not stop:
+        await update.message.reply_text("Please provide a stop name after /departures")
+        return
+    try:
+        url = f"{API_URL}/departures?format=text&chatgpt=true"
+        resp = requests.post(url, json={"stop": stop})
+        if resp.status_code == 200:
+            await update.message.reply_text(resp.text)
+        else:
+            await update.message.reply_text(f"Error: {resp.text}")
+    except Exception as exc:
+        await update.message.reply_text(f"Request failed: {exc}")
+
+
+async def cmd_stops(update, context):
+    query = update.message.text.partition(" ")[2].strip()
+    if not query:
+        await update.message.reply_text("Please provide search text after /stops")
+        return
+    try:
+        url = f"{API_URL}/stops?format=text&chatgpt=true"
+        resp = requests.post(url, json={"query": query})
         if resp.status_code == 200:
             await update.message.reply_text(resp.text)
         else:
@@ -43,6 +121,10 @@ def main() -> None:
     API_URL = args.api_url
 
     application = Application.builder().token(BOT_TOKEN).build()
+    application.add_handler(CommandHandler("start", cmd_start))
+    application.add_handler(CommandHandler("search", cmd_search))
+    application.add_handler(CommandHandler("departures", cmd_departures))
+    application.add_handler(CommandHandler("stops", cmd_stops))
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_text))
     application.run_polling()
 

--- a/tests/test_chatgpt_helper.py
+++ b/tests/test_chatgpt_helper.py
@@ -45,3 +45,41 @@ def test_parse_query_chatgpt_requires_key():
         with pytest.raises(RuntimeError):
             chatgpt_helper.parse_query_chatgpt('hi')
 
+
+@patch('src.chatgpt_helper.requests.post')
+def test_classify_query_chatgpt_parses_json(mock_post):
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {
+        'choices': [
+            {'message': {'content': '{"endpoint": "departures", "stop": "Bozen"}'}}
+        ]
+    }
+    mock_post.return_value = mock_resp
+    with patch.dict(os.environ, {'OPENAI_API_KEY': 'sk-test'}):
+        result = chatgpt_helper.classify_query_chatgpt('foo')
+    assert result == {'endpoint': 'departures', 'stop': 'Bozen'}
+    mock_post.assert_called_once()
+
+
+@patch('src.chatgpt_helper.requests.post')
+def test_classify_query_chatgpt_invalid_json_returns_empty(mock_post):
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {
+        'choices': [
+            {'message': {'content': 'not json'}}
+        ]
+    }
+    mock_post.return_value = mock_resp
+    with patch.dict(os.environ, {'OPENAI_API_KEY': 'sk-test'}):
+        result = chatgpt_helper.classify_query_chatgpt('dummy')
+    assert result == {}
+    mock_post.assert_called_once()
+
+
+def test_classify_query_chatgpt_requires_key():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(RuntimeError):
+            chatgpt_helper.classify_query_chatgpt('hi')
+


### PR DESCRIPTION
## Summary
- enhance `chatgpt_helper` with `classify_query_chatgpt`
- support `/search`, `/departures`, and `/stops` commands in the Telegram bot
- detect the desired API endpoint automatically using ChatGPT
- expose a start command that shows a keyboard
- test the new ChatGPT helper function

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867895f67588321a8fe887fc9cb8185