### PR TITLE
Add autostart option for Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ Forward messages to the API using the example bot:
 export TELEGRAM_TOKEN=your_token
 python -m src.telegram_bot --api-url http://localhost:8000
 ```
+Add `--start-server` to launch the API with `uvicorn` automatically:
+```bash
+export TELEGRAM_TOKEN=your_token
+python -m src.telegram_bot --api-url http://localhost:8000 --start-server
+```
 Use `--api-url` to specify the address of the running API. The option
 defaults to the value of the `API_URL` environment variable or
 `http://localhost:8000` if unset.

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import argparse
+import subprocess
+import time
 
 if sys.version_info < (3, 8):
     raise RuntimeError("telegram_bot.py requires Python 3.8 or newer")
@@ -18,6 +20,11 @@ def parse_args(args=None):
         "--api-url",
         default=API_URL,
         help="Base URL of the API server",
+    )
+    parser.add_argument(
+        "--start-server",
+        action="store_true",
+        help="Start the API server before launching the bot",
     )
     return parser.parse_args(args)
 
@@ -42,9 +49,22 @@ def main() -> None:
     args = parse_args()
     API_URL = args.api_url
 
-    application = Application.builder().token(BOT_TOKEN).build()
-    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_text))
-    application.run_polling()
+    server_proc = None
+    if args.start_server:
+        cmd = ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--reload"]
+        server_proc = subprocess.Popen(cmd)
+        # Give the server a moment to start
+        time.sleep(1)
+
+    try:
+        application = Application.builder().token(BOT_TOKEN).build()
+        application.add_handler(
+            MessageHandler(filters.TEXT & ~filters.COMMAND, handle_text)
+        )
+        application.run_polling()
+    finally:
+        if server_proc:
+            server_proc.terminate()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow `src.telegram_bot` to spawn a uvicorn server before running the bot
- update README with new `--start-server` usage example

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686788a19094832187e1e6ffa8130a4a