### PR TITLE
Make ChatGPT optional for telegram bot

### DIFF
--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -3,6 +3,7 @@ import sys
 import argparse
 import subprocess
 import time
+import logging
 
 if sys.version_info < (3, 8):
     raise RuntimeError("telegram_bot.py requires Python 3.8 or newer")
@@ -12,9 +13,14 @@ from telegram import ReplyKeyboardMarkup
 from telegram.ext import Application, MessageHandler, CommandHandler, filters
 
 from . import chatgpt_helper
+from .logging_utils import setup_logging
+
+logger = logging.getLogger(__name__)
+setup_logging()
 
 API_URL = os.getenv("API_URL", "http://localhost:8000")
 BOT_TOKEN = os.getenv("TELEGRAM_TOKEN")
+USE_CHATGPT = False
 
 
 def parse_args(args=None):
@@ -29,29 +35,43 @@ def parse_args(args=None):
         action="store_true",
         help="Start the API server before launching the bot",
     )
+    parser.add_argument(
+        "--chatgpt",
+        action="store_true",
+        help="Enable ChatGPT-based request handling",
+    )
     return parser.parse_args(args)
 
 async def handle_text(update, context):
     """Handle free text by classifying the request via ChatGPT."""
     text = update.message.text
+    logger.info("Received message: %s", text)
     try:
-        info = chatgpt_helper.classify_query_chatgpt(text)
+        info = chatgpt_helper.classify_query_chatgpt(text) if USE_CHATGPT else {}
     except Exception as exc:
+        logger.error("ChatGPT classification failed: %s", exc)
         info = {}
 
     endpoint = (info.get("endpoint") or "search").lower()
     if endpoint == "departures":
         stop = info.get("stop") or text
-        url = f"{API_URL}/departures?format=text&chatgpt=true"
+        url = f"{API_URL}/departures?format=text"
+        if USE_CHATGPT:
+            url += "&chatgpt=true"
         payload = {"stop": stop}
     elif endpoint == "stops":
         query = info.get("query") or text
-        url = f"{API_URL}/stops?format=text&chatgpt=true"
+        url = f"{API_URL}/stops?format=text"
+        if USE_CHATGPT:
+            url += "&chatgpt=true"
         payload = {"query": query}
     else:
-        url = f"{API_URL}/search?chatgpt=true"
+        url = f"{API_URL}/search"
+        if USE_CHATGPT:
+            url += "?chatgpt=true"
         payload = {"text": text}
 
+    logger.info("Sending request to %s with payload %s", url, payload)
     try:
         resp = requests.post(url, json=payload)
         if resp.status_code == 200:
@@ -76,8 +96,14 @@ async def cmd_search(update, context):
     if not query:
         await update.message.reply_text("Please provide a query after /search")
         return
+    logger.info("/search %s", query)
     try:
-        resp = requests.post(f"{API_URL}/search?chatgpt=true", json={"text": query})
+        url = f"{API_URL}/search"
+        if USE_CHATGPT:
+            url += "?chatgpt=true"
+        payload = {"text": query}
+        logger.info("Sending request to %s with payload %s", url, payload)
+        resp = requests.post(url, json=payload)
         if resp.status_code == 200:
             await update.message.reply_text(resp.text)
         else:
@@ -91,9 +117,14 @@ async def cmd_departures(update, context):
     if not stop:
         await update.message.reply_text("Please provide a stop name after /departures")
         return
+    logger.info("/departures %s", stop)
     try:
-        url = f"{API_URL}/departures?format=text&chatgpt=true"
-        resp = requests.post(url, json={"stop": stop})
+        url = f"{API_URL}/departures?format=text"
+        if USE_CHATGPT:
+            url += "&chatgpt=true"
+        payload = {"stop": stop}
+        logger.info("Sending request to %s with payload %s", url, payload)
+        resp = requests.post(url, json=payload)
         if resp.status_code == 200:
             await update.message.reply_text(resp.text)
         else:
@@ -107,9 +138,14 @@ async def cmd_stops(update, context):
     if not query:
         await update.message.reply_text("Please provide search text after /stops")
         return
+    logger.info("/stops %s", query)
     try:
-        url = f"{API_URL}/stops?format=text&chatgpt=true"
-        resp = requests.post(url, json={"query": query})
+        url = f"{API_URL}/stops?format=text"
+        if USE_CHATGPT:
+            url += "&chatgpt=true"
+        payload = {"query": query}
+        logger.info("Sending request to %s with payload %s", url, payload)
+        resp = requests.post(url, json=payload)
         if resp.status_code == 200:
             await update.message.reply_text(resp.text)
         else:
@@ -119,21 +155,26 @@ async def cmd_stops(update, context):
 
 
 def main() -> None:
-    global API_URL
+    global API_URL, USE_CHATGPT
 
     if not BOT_TOKEN:
         raise RuntimeError("TELEGRAM_TOKEN environment variable not set")
 
     args = parse_args()
     API_URL = args.api_url
+    USE_CHATGPT = args.chatgpt
 
 
     server_proc = None
     if args.start_server:
         cmd = ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--reload"]
-        server_proc = subprocess.Popen(cmd)
-        # Give the server a moment to start
-        time.sleep(1)
+        try:
+            server_proc = subprocess.Popen(cmd)
+            # Give the server a moment to start
+            time.sleep(1)
+        except OSError as exc:
+            logger.error("Failed to start server: %s", exc)
+            server_proc = None
 
     try:
         application = Application.builder().token(BOT_TOKEN).build()

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -9,8 +9,13 @@ from src import telegram_bot
 def test_parse_args_default():
     args = telegram_bot.parse_args([])
     assert args.api_url == "http://localhost:8000"
+    assert args.chatgpt is False
 
 
 def test_parse_args_override():
     args = telegram_bot.parse_args(["--api-url", "http://1.2.3.4:8000"])
     assert args.api_url == "http://1.2.3.4:8000"
+
+def test_parse_args_chatgpt():
+    args = telegram_bot.parse_args(["--chatgpt"])
+    assert args.chatgpt is True


### PR DESCRIPTION
## Summary
- add optional `--chatgpt` flag to telegram bot
- log incoming telegram requests and API calls
- gracefully handle server startup errors
- update tests for the optional flag

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68678df84cc48321a8c6d786c8a11f78