### PR TITLE
Fix command buttons in Telegram bot

### DIFF
--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -137,6 +137,10 @@ def main() -> None:
 
     try:
         application = Application.builder().token(BOT_TOKEN).build()
+        application.add_handler(CommandHandler("start", cmd_start))
+        application.add_handler(CommandHandler("search", cmd_search))
+        application.add_handler(CommandHandler("departures", cmd_departures))
+        application.add_handler(CommandHandler("stops", cmd_stops))
         application.add_handler(
             MessageHandler(filters.TEXT & ~filters.COMMAND, handle_text)
         )
@@ -144,14 +148,6 @@ def main() -> None:
     finally:
         if server_proc:
             server_proc.terminate()
-
-    application = Application.builder().token(BOT_TOKEN).build()
-    application.add_handler(CommandHandler("start", cmd_start))
-    application.add_handler(CommandHandler("search", cmd_search))
-    application.add_handler(CommandHandler("departures", cmd_departures))
-    application.add_handler(CommandHandler("stops", cmd_stops))
-    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_text))
-    application.run_polling()
 
 
 


### PR DESCRIPTION
## Summary
- fix handler registration to include commands during bot startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68678ee61fb88321ae847c73f9c64103