### PR TITLE
Add endpoint and language detection

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -42,14 +42,15 @@ def search(req: SearchRequest, format: Optional[str] = None, chatgpt: bool = Fal
     logger.debug("/search result: %s", result)
     if format == "json":
         return result
+    lang = params.get("lang", "de")
     if chatgpt:
         text = chatgpt_helper.narrative_trip_summary(result)
         return PlainTextResponse(text)
     if format == "text":
-        text = format_search_result(result, legs_only=False)
+        text = format_search_result(result, legs_only=False, lang=lang)
         return PlainTextResponse(text)
     # default plain-text response lists the individual legs
-    text = format_search_result(result, legs_only=True)
+    text = format_search_result(result, legs_only=True, lang=lang)
     return PlainTextResponse(text)
 
 
@@ -63,7 +64,7 @@ def departures(req: DMRequest, format: str = "json", chatgpt: bool = False):
     result = efa_api.dm_request(req.stop, req.limit, lang)
     logger.debug("/departures result: %s", result)
     if format == "text":
-        text = format_departures_result(result)
+        text = format_departures_result(result, lang=lang)
         if chatgpt:
             text = chatgpt_helper.reformat_summary(text)
         return PlainTextResponse(text)
@@ -80,7 +81,7 @@ def stops(req: StopFinderRequest, format: str = "json", chatgpt: bool = False):
     result = efa_api.stopfinder_request(req.query, lang)
     logger.debug("/stops result: %s", result)
     if format == "text":
-        text = format_stops_result(result)
+        text = format_stops_result(result, lang=lang)
         if chatgpt:
             text = chatgpt_helper.reformat_summary(text)
         return PlainTextResponse(text)

--- a/src/nlp_parser.py
+++ b/src/nlp_parser.py
@@ -132,3 +132,42 @@ def parse_query(text: str) -> Dict[str, Optional[str]]:
     logger.debug("Parsed parameters: %s", result)
     return result
 
+
+# --- new helper for endpoint detection ---
+
+_KEYWORDS_DEPARTURES = {
+    "de": ["abfahrt", "abfahrten"],
+    "en": ["departure", "departures"],
+    "it": ["partenza", "partenze"],
+}
+
+_KEYWORDS_STOPS = {
+    "de": ["haltestelle", "haltestellen", "stop", "stops"],
+    "en": ["stop", "stops", "station", "stations"],
+    "it": ["fermata", "fermate"],
+}
+
+
+def classify_request(text: str) -> Dict[str, str]:
+    """Classify the user request and detect the language.
+
+    The returned dictionary contains an ``endpoint`` key with one of
+    ``"search"``, ``"departures"`` or ``"stops"``.  Additional parameters
+    may be included for the chosen endpoint, similar to the ChatGPT helper.
+    """
+
+    lang = _detect_language(text)
+    text_l = text.lower()
+
+    for kw in _KEYWORDS_DEPARTURES.get(lang, []):
+        if kw in text_l:
+            return {"endpoint": "departures", "stop": text, "lang": lang}
+
+    for kw in _KEYWORDS_STOPS.get(lang, []):
+        if kw in text_l:
+            return {"endpoint": "stops", "query": text, "lang": lang}
+
+    params = parse_query(text)
+    params["endpoint"] = "search"
+    return params
+

--- a/src/summaries.py
+++ b/src/summaries.py
@@ -3,6 +3,52 @@
 from typing import Any, Dict, List
 
 
+_TL = {
+    "de": {
+        "from": "Von",
+        "to": "Nach",
+        "departures_for": "Abfahrten f\u00fcr {stop}",
+        "departures": "Abfahrten:",
+        "direction": "Richtung",
+        "platform": "Steig",
+        "at": "um {time} Uhr",
+        "on_foot": "zu Fu\u00df",
+        "with": "mit {mode}",
+        "stops_found": "Gefundene Haltestellen:",
+        "arrival": "An:",
+        "departure": "Ab:",
+    },
+    "en": {
+        "from": "From",
+        "to": "To",
+        "departures_for": "Departures for {stop}",
+        "departures": "Departures:",
+        "direction": "Direction",
+        "platform": "Platform",
+        "at": "at {time}",
+        "on_foot": "on foot",
+        "with": "with {mode}",
+        "stops_found": "Stops found:",
+        "arrival": "Arr:",
+        "departure": "Dep:",
+    },
+    "it": {
+        "from": "Da",
+        "to": "A",
+        "departures_for": "Partenze per {stop}",
+        "departures": "Partenze:",
+        "direction": "Direzione",
+        "platform": "Banchina",
+        "at": "alle {time}",
+        "on_foot": "a piedi",
+        "with": "con {mode}",
+        "stops_found": "Fermate trovate:",
+        "arrival": "Arrivo:",
+        "departure": "Partenza:",
+    },
+}
+
+
 def _extract_time(data: Any) -> str:
     """Return a time string from different data structures."""
     if isinstance(data, str):
@@ -27,7 +73,9 @@ def _plural(word: str, count: int) -> str:
     return word if count == 1 else f"{word}s"
 
 
-def format_search_result(result: Dict[str, Any], legs_only: bool = False) -> str:
+def format_search_result(
+    result: Dict[str, Any], legs_only: bool = False, lang: str = "de"
+) -> str:
     """Return a readable summary of a trip search result.
 
     Parameters
@@ -40,6 +88,8 @@ def format_search_result(result: Dict[str, Any], legs_only: bool = False) -> str
     """
     if not isinstance(result, dict):
         return str(result)
+
+    tl = _TL.get(lang, _TL["en"])
 
     from_stop = (
         result.get("from_stop")
@@ -68,9 +118,9 @@ def format_search_result(result: Dict[str, Any], legs_only: bool = False) -> str
     if not trips:
         header_parts = []
         if from_stop:
-            header_parts.append(f"from {from_stop}")
+            header_parts.append(f"{tl['from'].lower()} {from_stop}")
         if to_stop:
-            header_parts.append(f"to {to_stop}")
+            header_parts.append(f"{tl['to'].lower()} {to_stop}")
         header = " ".join(header_parts) if header_parts else "found"
         return f"0 trips {header}."
 
@@ -105,22 +155,22 @@ def format_search_result(result: Dict[str, Any], legs_only: bool = False) -> str
             or ""
         )
         if not mode_name or "fuß" in mode_name.lower() or "walk" in mode_name.lower():
-            mode_desc = "zu Fuß"
+            mode_desc = tl["on_foot"]
         else:
-            mode_desc = f"mit {mode_name}"
-        origin_line = f"Von: {start_name}"
+            mode_desc = tl["with"].format(mode=mode_name)
+        origin_line = f"{tl['from']}: {start_name}"
         if start_time:
-            origin_line += f" um {start_time} Uhr {mode_desc}"
+            origin_line += " " + tl["at"].format(time=start_time) + f" {mode_desc}"
         else:
             origin_line += f" {mode_desc}"
         lines.append(origin_line)
         dest_name = dest.get("name") or to_stop
-        lines.append(f"Nach: {dest_name}")
+        lines.append(f"{tl['to']}: {dest_name}")
     elif not legs_only:
         start_name = from_stop
-        lines.append(f"Von: {start_name}")
+        lines.append(f"{tl['from']}: {start_name}")
         if to_stop:
-            lines.append(f"Nach: {to_stop}")
+            lines.append(f"{tl['to']}: {to_stop}")
 
     if leg_list and not legs_only:
         lines.append("")
@@ -144,44 +194,44 @@ def format_search_result(result: Dict[str, Any], legs_only: bool = False) -> str
         )
         if not line_name or "fuß" in line_name.lower() or "walk" in line_name.lower():
             if legs_only:
-                line_desc = "zu Fuß"
+                line_desc = tl["on_foot"]
             else:
                 line_desc = "zu Fuß"
         else:
             if legs_only:
                 line_desc = line_name
             else:
-                line_desc = f"mit {line_name}"
+                line_desc = tl["with"].format(mode=line_name)
             direction = (leg.get("mode") or {}).get("destination") or ""
             if direction:
-                line_desc += f" Richtung {direction}"
+                line_desc += f" {tl['direction']} {direction}"
         if legs_only:
             lines.append(line_desc)
             start_line = f"{o_time}: {o_name}" if o_time else o_name
             origin_platform = origin.get("platform") or origin.get("platformName")
             if origin_platform:
-                start_line += f" von Steig {origin_platform}"
+                start_line += f" von {tl['platform']} {origin_platform}"
             lines.append(start_line)
             end_line = f"{d_time}: {d_name}" if d_time else d_name
             platform = dest.get("platform") or dest.get("platformName")
             if platform:
-                end_line += f" auf Steig {platform}"
+                end_line += f" auf {tl['platform']} {platform}"
             lines.append(end_line)
         else:
-            dep_line = f"Ab: {o_name}"
+            dep_line = f"{tl['departure']} {o_name}"
             if o_time:
-                dep_line += f" um {o_time} Uhr {line_desc}"
+                dep_line += " " + tl["at"].format(time=o_time) + f" {line_desc}"
             else:
                 dep_line += f" {line_desc}"
             origin_platform = origin.get("platform") or origin.get("platformName")
             if origin_platform:
-                dep_line += f" von Steig {origin_platform}"
-            arr_line = f"An: {d_name}"
+                dep_line += f" von {tl['platform']} {origin_platform}"
+            arr_line = f"{tl['arrival']} {d_name}"
             if d_time:
-                arr_line += f" um {d_time} Uhr"
+                arr_line += " " + tl["at"].format(time=d_time)
             platform = dest.get("platform") or dest.get("platformName")
             if platform:
-                arr_line += f" auf Steig {platform}"
+                arr_line += f" auf {tl['platform']} {platform}"
             lines.append(dep_line)
             lines.append(arr_line)
         if idx < len(leg_list) - 1:
@@ -190,10 +240,12 @@ def format_search_result(result: Dict[str, Any], legs_only: bool = False) -> str
     return "\n".join(lines)
 
 
-def format_departures_result(result: Dict[str, Any]) -> str:
+def format_departures_result(result: Dict[str, Any], lang: str = "de") -> str:
     """Return a readable summary of departures."""
     if not isinstance(result, dict):
         return str(result)
+
+    tl = _TL.get(lang, _TL["en"])
 
     stop_name = (
         result.get("stop_name")
@@ -223,7 +275,7 @@ def format_departures_result(result: Dict[str, Any]) -> str:
         suffix = f" for '{stop_name}'" if stop_name else ""
         return f"0 departures{suffix}."
 
-    lines = [f"Abfahrten für {stop_name}:"] if stop_name else ["Abfahrten:"]
+    lines = [tl["departures_for"].format(stop=stop_name)] if stop_name else [tl["departures"]]
 
     for dep in departures:
         time = (
@@ -244,11 +296,11 @@ def format_departures_result(result: Dict[str, Any]) -> str:
         if line_name:
             parts.append(line_name)
         if direction:
-            parts.append(f"Richtung {direction}")
+            parts.append(f"{tl['direction']} {direction}")
         if platform:
-            parts.append(f"Steig {platform}")
+            parts.append(f"{tl['platform']} {platform}")
         if time:
-            parts.append(f"um {time} Uhr")
+            parts.append(tl["at"].format(time=time))
 
         entry = " ".join(parts)
         lines.append(entry.strip())
@@ -256,10 +308,12 @@ def format_departures_result(result: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def format_stops_result(result: Dict[str, Any]) -> str:
+def format_stops_result(result: Dict[str, Any], lang: str = "de") -> str:
     """Return a readable summary of stop suggestions."""
     if not isinstance(result, dict):
         return str(result)
+
+    tl = _TL.get(lang, _TL["en"])
 
     # Gracefully handle missing or null fields in the nested structure
     stopfinder = result.get("stopFinder")
@@ -308,7 +362,7 @@ def format_stops_result(result: Dict[str, Any]) -> str:
     entries.sort(key=lambda e: e["type"])
     best_idx = entries.index(best_entry) if best_entry in entries else None
 
-    lines = ["Gefundene Haltestellen:"]
+    lines = [tl["stops_found"]]
     for idx, entry in enumerate(entries):
         if best_idx is not None and idx == best_idx:
             lines.append(f"[TOP] {entry['text']}")

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -12,7 +12,7 @@ import requests
 from telegram import ReplyKeyboardMarkup
 from telegram.ext import Application, MessageHandler, CommandHandler, filters
 
-from . import chatgpt_helper
+from . import chatgpt_helper, nlp_parser
 from .logging_utils import setup_logging
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,10 @@ async def handle_text(update, context):
     text = update.message.text
     logger.info("Received message: %s", text)
     try:
-        info = chatgpt_helper.classify_query_chatgpt(text) if USE_CHATGPT else {}
+        if USE_CHATGPT:
+            info = chatgpt_helper.classify_query_chatgpt(text)
+        else:
+            info = nlp_parser.classify_request(text)
     except Exception as exc:
         logger.error("ChatGPT classification failed: %s", exc)
         info = {}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,7 +30,7 @@ def test_search_endpoint_text(mock_parse_query, mock_search_efa, mock_format):
     response = client.post('/search?format=text', json={'text': 'foo'})
     assert response.status_code == 200
     assert response.text == 'summary'
-    mock_format.assert_called_once_with({'dummy': True}, legs_only=False)
+    mock_format.assert_called_once_with({'dummy': True}, legs_only=False, lang='de')
 
 
 @patch('src.main.format_search_result', return_value='legs')
@@ -43,7 +43,7 @@ def test_search_endpoint_default(mock_parse_query, mock_search_efa, mock_format)
     response = client.post('/search', json={'text': 'foo'})
     assert response.status_code == 200
     assert response.text == 'legs'
-    mock_format.assert_called_once_with({'dummy': True}, legs_only=True)
+    mock_format.assert_called_once_with({'dummy': True}, legs_only=True, lang='de')
 
 
 @patch('src.main.chatgpt_helper.narrative_trip_summary', return_value='better')
@@ -93,7 +93,7 @@ def test_departures_endpoint_text(mock_dm_request, mock_format):
     response = client.post('/departures?format=text', json={'stop': 'B', 'limit': 1})
     assert response.status_code == 200
     assert response.text == 'dep'
-    mock_format.assert_called_once_with({'ok': True})
+    mock_format.assert_called_once_with({'ok': True}, lang='de')
 
 
 @patch('src.main.chatgpt_helper.reformat_summary', return_value='better dep')
@@ -105,7 +105,7 @@ def test_departures_endpoint_chatgpt(mock_dm_request, mock_format, mock_reformat
     response = client.post('/departures?format=text&chatgpt=true', json={'stop': 'B', 'limit': 1})
     assert response.status_code == 200
     assert response.text == 'better dep'
-    mock_format.assert_called_once_with({'ok': True})
+    mock_format.assert_called_once_with({'ok': True}, lang='de')
     mock_reformat.assert_called_once_with('dep')
 
 
@@ -121,25 +121,27 @@ def test_stops_endpoint(mock_stopfinder_request, mock_detect):
     mock_stopfinder_request.assert_called_once_with('Brixen', 'de')
 
 
+@patch('src.main.nlp_parser.detect_language', return_value='de')
 @patch('src.main.format_stops_result', return_value='stops')
 @patch('src.main.efa_api.stopfinder_request')
-def test_stops_endpoint_text(mock_stopfinder_request, mock_format):
+def test_stops_endpoint_text(mock_stopfinder_request, mock_format, mock_detect):
     mock_stopfinder_request.return_value = {'foo': 'bar'}
     client = TestClient(app)
     response = client.post('/stops?format=text', json={'query': 'xyz'})
     assert response.status_code == 200
     assert response.text == 'stops'
-    mock_format.assert_called_once_with({'foo': 'bar'})
+    mock_format.assert_called_once_with({'foo': 'bar'}, lang='de')
 
 
 @patch('src.main.chatgpt_helper.reformat_summary', return_value='better stops')
+@patch('src.main.nlp_parser.detect_language', return_value='de')
 @patch('src.main.format_stops_result', return_value='stops')
 @patch('src.main.efa_api.stopfinder_request')
-def test_stops_endpoint_chatgpt(mock_stopfinder_request, mock_format, mock_reformat):
+def test_stops_endpoint_chatgpt(mock_stopfinder_request, mock_format, mock_detect, mock_reformat):
     mock_stopfinder_request.return_value = {'foo': 'bar'}
     client = TestClient(app)
     response = client.post('/stops?format=text&chatgpt=true', json={'query': 'xyz'})
     assert response.status_code == 200
     assert response.text == 'better stops'
-    mock_format.assert_called_once_with({'foo': 'bar'})
+    mock_format.assert_called_once_with({'foo': 'bar'}, lang='de')
     mock_reformat.assert_called_once_with('stops')

--- a/tests/test_nlp_parser.py
+++ b/tests/test_nlp_parser.py
@@ -32,3 +32,25 @@ def test_parse_query_multiple_tokens():
     assert result.get("from_stop") == "Bozen"
     assert result.get("to_stop") == "Sterzing, Busbahnhof"
 
+
+def test_classify_request_departures():
+    text = "Abfahrten Brixen"
+    result = nlp_parser.classify_request(text)
+    assert result["endpoint"] == "departures"
+    assert result["stop"] == text
+
+
+def test_classify_request_stops():
+    text = "Haltestelle Brixen"
+    result = nlp_parser.classify_request(text)
+    assert result["endpoint"] == "stops"
+    assert result["query"] == text
+
+
+def test_classify_request_search():
+    text = "Wie komme ich von Bozen nach Meran?"
+    result = nlp_parser.classify_request(text)
+    assert result["endpoint"] == "search"
+    assert result.get("from_stop") == "Bozen"
+    assert result.get("to_stop") == "Meran"
+

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -34,6 +34,18 @@ def test_format_stops_result_handles_points_list():
     assert top_line.startswith("[TOP] ")
 
 
+def test_format_stops_result_english():
+    result = {
+        "stopFinder": {
+            "points": [
+                {"name": "A", "anyType": "stop", "quality": "10"}
+            ]
+        }
+    }
+    summary = format_stops_result(result, lang="en")
+    assert "Stops found:" in summary
+
+
 def test_format_search_result_handles_points_leg():
     result = {
         "trips": {
@@ -180,4 +192,22 @@ def test_format_departures_result_structured_time():
 
     summary = format_departures_result(result)
     assert "um 09:15 Uhr" in summary
+
+
+def test_format_departures_result_english():
+    result = {
+        "departures": {
+            "departure": [
+                {
+                    "time": "08:00",
+                    "servingLine": {"name": "Bus", "direction": "Town"},
+                    "platformName": "1",
+                }
+            ]
+        }
+    }
+
+    summary = format_departures_result(result, lang="en")
+    assert "Departures" in summary
+    assert "Platform" in summary
 


### PR DESCRIPTION
## Summary
- detect API endpoint and language via `classify_request`
- localize summaries in English and Italian
- use detected language when formatting results
- update Telegram bot to classify without ChatGPT
- expand tests for new behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68679131878c8321a8516cc755da9c6b