### PR TITLE
Add dotenv-based config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 # Editor directories
 .vscode/
 .idea/
+.env

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ uvicorn src.main:app --host 0.0.0.0 --reload
 ## Configuration
 - `EFA_BASE_URL` – base URL of the Mentz‑EFA endpoint
 - `OPENAI_API_KEY` – enable ChatGPT features
+- `TELEGRAM_TOKEN` – required for the Telegram bot
+- `API_URL` – base URL of the API used by the Telegram bot
+
+Environment variables can also be stored in a `.env` file in the project root.
+The file is loaded automatically and should not be committed to version control.
 
 Example:
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest
 httpx<0.25
 langdetect
 python-telegram-bot
+python-dotenv

--- a/src/chatgpt_helper.py
+++ b/src/chatgpt_helper.py
@@ -1,7 +1,8 @@
-import os
 import json
 import logging
 import requests
+
+from .config import OPENAI_API_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -10,7 +11,7 @@ API_URL = "https://api.openai.com/v1/chat/completions"
 
 def parse_query_chatgpt(text: str) -> dict:
     """Parse the query text via the OpenAI ChatGPT API."""
-    api_key = os.getenv("OPENAI_API_KEY")
+    api_key = OPENAI_API_KEY
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
 
@@ -54,7 +55,7 @@ def classify_query_chatgpt(text: str) -> dict:
     is one of ``"search"``, ``"departures"`` or ``"stops"``.  Additional keys
     provide the extracted parameters for the chosen endpoint.
     """
-    api_key = os.getenv("OPENAI_API_KEY")
+    api_key = OPENAI_API_KEY
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
 
@@ -102,7 +103,7 @@ def reformat_summary(text: str) -> str:
     response as plain text. The API key is read from the ``OPENAI_API_KEY``
     environment variable.
     """
-    api_key = os.getenv("OPENAI_API_KEY")
+    api_key = OPENAI_API_KEY
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
 
@@ -139,7 +140,7 @@ def narrative_trip_summary(result: dict) -> str:
     """Return a friendly ChatGPT summary for a trip search result."""
     from .summaries import format_search_result
 
-    api_key = os.getenv("OPENAI_API_KEY")
+    api_key = OPENAI_API_KEY
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,13 @@
+from dotenv import load_dotenv, find_dotenv
+
+# Load .env file if it exists
+_env_file = find_dotenv()
+if _env_file:
+    load_dotenv(_env_file)
+
+import os
+
+EFA_BASE_URL = os.getenv("EFA_BASE_URL", "https://efa.sta.bz.it/apb")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+API_URL = os.getenv("API_URL", "http://localhost:8000")

--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -1,7 +1,8 @@
-import os
 from typing import Dict, Any, List, Optional
 import logging
 import requests
+
+from .config import EFA_BASE_URL
 
 from .logging_utils import setup_logging
 from . import nlp_parser
@@ -9,7 +10,7 @@ from . import nlp_parser
 logger = logging.getLogger(__name__)
 setup_logging()
 
-BASE_URL = os.environ.get("EFA_BASE_URL", "https://efa.sta.bz.it/apb")
+BASE_URL = EFA_BASE_URL
 
 
 def get_stop_code(query: str, lang: Optional[str] = None) -> str:

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import argparse
 import subprocess
@@ -9,6 +8,8 @@ if sys.version_info < (3, 8):
     raise RuntimeError("telegram_bot.py requires Python 3.8 or newer")
 
 import requests
+
+from .config import API_URL as CONFIG_API_URL, TELEGRAM_TOKEN
 from telegram import ReplyKeyboardMarkup, ForceReply
 from telegram.ext import (
     Application,
@@ -24,8 +25,8 @@ from .logging_utils import setup_logging
 logger = logging.getLogger(__name__)
 setup_logging()
 
-API_URL = os.getenv("API_URL", "http://localhost:8000")
-BOT_TOKEN = os.getenv("TELEGRAM_TOKEN")
+API_URL = CONFIG_API_URL
+BOT_TOKEN = TELEGRAM_TOKEN
 USE_CHATGPT = False
 
 # Conversation states for interactive commands

--- a/tests/test_chatgpt_helper.py
+++ b/tests/test_chatgpt_helper.py
@@ -18,7 +18,7 @@ def test_parse_query_chatgpt_parses_json(mock_post):
         ]
     }
     mock_post.return_value = mock_resp
-    with patch.dict(os.environ, {'OPENAI_API_KEY': 'sk-test'}):
+    with patch('src.chatgpt_helper.OPENAI_API_KEY', 'sk-test'):
         result = chatgpt_helper.parse_query_chatgpt('dummy query')
     assert result == {'from_stop': 'A', 'to_stop': 'B'}
     mock_post.assert_called_once()
@@ -34,14 +34,14 @@ def test_parse_query_chatgpt_invalid_json_returns_empty(mock_post):
         ]
     }
     mock_post.return_value = mock_resp
-    with patch.dict(os.environ, {'OPENAI_API_KEY': 'sk-test'}):
+    with patch('src.chatgpt_helper.OPENAI_API_KEY', 'sk-test'):
         result = chatgpt_helper.parse_query_chatgpt('dummy')
     assert result == {}
     mock_post.assert_called_once()
 
 
 def test_parse_query_chatgpt_requires_key():
-    with patch.dict(os.environ, {}, clear=True):
+    with patch('src.chatgpt_helper.OPENAI_API_KEY', None):
         with pytest.raises(RuntimeError):
             chatgpt_helper.parse_query_chatgpt('hi')
 
@@ -56,7 +56,7 @@ def test_classify_query_chatgpt_parses_json(mock_post):
         ]
     }
     mock_post.return_value = mock_resp
-    with patch.dict(os.environ, {'OPENAI_API_KEY': 'sk-test'}):
+    with patch('src.chatgpt_helper.OPENAI_API_KEY', 'sk-test'):
         result = chatgpt_helper.classify_query_chatgpt('foo')
     assert result == {'endpoint': 'departures', 'stop': 'Bozen'}
     mock_post.assert_called_once()
@@ -72,14 +72,14 @@ def test_classify_query_chatgpt_invalid_json_returns_empty(mock_post):
         ]
     }
     mock_post.return_value = mock_resp
-    with patch.dict(os.environ, {'OPENAI_API_KEY': 'sk-test'}):
+    with patch('src.chatgpt_helper.OPENAI_API_KEY', 'sk-test'):
         result = chatgpt_helper.classify_query_chatgpt('dummy')
     assert result == {}
     mock_post.assert_called_once()
 
 
 def test_classify_query_chatgpt_requires_key():
-    with patch.dict(os.environ, {}, clear=True):
+    with patch('src.chatgpt_helper.OPENAI_API_KEY', None):
         with pytest.raises(RuntimeError):
             chatgpt_helper.classify_query_chatgpt('hi')
 


### PR DESCRIPTION
## Summary
- add python-dotenv dependency and config module
- load environment variables from a `.env` file when available
- use config constants in API helpers and bot
- document `.env` usage and ignore the file in git
- adapt tests to patch configuration constants

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867b7f0d53883218518968602fde34d