### PR TITLE
Add tests for short German queries

### DIFF
--- a/src/nlp_parser.py
+++ b/src/nlp_parser.py
@@ -71,7 +71,9 @@ def parse_query(text: str) -> Dict[str, Optional[str]]:
 
     logger.debug("Parsing text (%s): %s", lang, text)
     doc = nlp(text)
-    stops = [t.text for t in doc if t.pos_ == "PROPN"]
+    stops = [t.text for t in doc if t.pos_ in {"PROPN", "NOUN"}]
+    if not stops:
+        stops = [t.text for t in doc if t.text and t.text[0].isupper()]
 
     # Filter out tokens that look like a time expression
     stops = [s for s in stops if not _RE_TIME_TOKEN.fullmatch(s)]
@@ -92,6 +94,14 @@ def parse_query(text: str) -> Dict[str, Optional[str]]:
 
     if m_from:
         from_stop = m_from.group(1).strip(" ,.")
+    elif m_to:
+        before = text[:m_to.start()].strip()
+        if before:
+            from_stop = before.split()[-1].strip(" ,.")
+        elif stops:
+            from_stop = stops.pop(0)
+        else:
+            from_stop = None
     elif stops:
         from_stop = stops.pop(0)
     else:

--- a/tests/test_nlp_parser.py
+++ b/tests/test_nlp_parser.py
@@ -33,6 +33,20 @@ def test_parse_query_multiple_tokens():
     assert result.get("to_stop") == "Sterzing, Busbahnhof"
 
 
+def test_parse_query_german_short():
+    text = "Meran nach Bozen"
+    result = nlp_parser.parse_query(text)
+    assert result.get("from_stop") == "Meran"
+    assert result.get("to_stop") == "Bozen"
+
+
+def test_parse_query_two_tokens():
+    text = "Meran Bozen"
+    result = nlp_parser.parse_query(text)
+    assert result.get("from_stop") == "Meran"
+    assert result.get("to_stop") == "Bozen"
+
+
 def test_classify_request_departures():
     text = "Abfahrten Brixen"
     result = nlp_parser.classify_request(text)


### PR DESCRIPTION
## Summary
- cover 'Meran nach Bozen' and 'Meran Bozen' in parser tests
- make `parse_query` handle short queries without explicit keywords

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867b8ac92bc8321953367482a5a6f42