### PR TITLE
Move logging setup to runtime

### DIFF
--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -4,11 +4,9 @@ import requests
 
 from .config import EFA_BASE_URL
 
-from .logging_utils import setup_logging
 from . import nlp_parser
 
 logger = logging.getLogger(__name__)
-setup_logging()
 
 BASE_URL = EFA_BASE_URL
 

--- a/src/main.py
+++ b/src/main.py
@@ -12,8 +12,6 @@ from .summaries import (
 )
 from .logging_utils import setup_logging
 
-# Configure logging; debug mode is controlled solely via CLI arguments
-setup_logging()
 logger = logging.getLogger(__name__)
 
 app = FastAPI()
@@ -89,6 +87,7 @@ def stops(req: StopFinderRequest, format: str = "json", chatgpt: bool = False):
 
 # Run via ``python -m src.main`` for debugging without auto-reload.
 if __name__ == "__main__" and __package__:
+    setup_logging()
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)
 

--- a/src/nlp_parser.py
+++ b/src/nlp_parser.py
@@ -4,10 +4,8 @@ import logging
 import spacy
 from langdetect import detect, DetectorFactory
 
-from .logging_utils import setup_logging
-
 logger = logging.getLogger(__name__)
-setup_logging()
+
 
 DetectorFactory.seed = 0
 

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -23,7 +23,6 @@ from . import chatgpt_helper, nlp_parser
 from .logging_utils import setup_logging
 
 logger = logging.getLogger(__name__)
-setup_logging()
 
 API_URL = CONFIG_API_URL
 BOT_TOKEN = TELEGRAM_TOKEN
@@ -187,6 +186,8 @@ async def cmd_stops(update, context):
 
 def main() -> None:
     global API_URL, USE_CHATGPT
+
+    setup_logging()
 
     if not BOT_TOKEN:
         raise RuntimeError("TELEGRAM_TOKEN environment variable not set")


### PR DESCRIPTION
## Summary
- avoid calling `setup_logging()` on import
- set up logging in the API and Telegram main entry points

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867bb74a6f0832184b3a286143eb0f5