### PR TITLE
Add stop name to departure header

### DIFF
--- a/src/summaries.py
+++ b/src/summaries.py
@@ -7,7 +7,7 @@ _TL = {
     "de": {
         "from": "Von",
         "to": "Nach",
-        "departures_for": "Abfahrten f\u00fcr {stop}",
+        "departures_for": "Abfahrten {stop}:",
         "departures": "Abfahrten:",
         "direction": "Richtung",
         "platform": "Steig",
@@ -21,7 +21,7 @@ _TL = {
     "en": {
         "from": "From",
         "to": "To",
-        "departures_for": "Departures for {stop}",
+        "departures_for": "Departures {stop}:",
         "departures": "Departures:",
         "direction": "Direction",
         "platform": "Platform",
@@ -35,7 +35,7 @@ _TL = {
     "it": {
         "from": "Da",
         "to": "A",
-        "departures_for": "Partenze per {stop}",
+        "departures_for": "Partenze {stop}:",
         "departures": "Partenze:",
         "direction": "Direzione",
         "platform": "Banchina",

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -98,7 +98,7 @@ def test_format_departures_result_formats_line():
     }
 
     summary = format_departures_result(result)
-    assert "Abfahrten f" in summary
+    assert summary.startswith("Abfahrten Brixen:")
     assert (
         "13:20 Citybus 320.1 Richtung Milland KG Arcobaleno Steig A" in summary
     )


### PR DESCRIPTION
## Summary
- show the stop name directly in departure summaries
- update tests for new wording

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d9e0c360832193a61a12923c69bf