### PR TITLE
Fix language handling for ChatGPT summaries

### DIFF
--- a/src/chatgpt_helper.py
+++ b/src/chatgpt_helper.py
@@ -10,6 +10,24 @@ logger = logging.getLogger(__name__)
 
 API_URL = "https://api.openai.com/v1/chat/completions"
 
+# System prompts in different languages for narrative summaries
+_PROMPTS = {
+    "de": (
+        "Formuliere aus den folgenden Verbindungsdaten einen kurzen und "
+        "freundlichen Text. Gib die Verbindungsdaten exakt wieder und "
+        "sprich die Person in Du-Form an."
+    ),
+    "en": (
+        "Write a short and friendly summary of the following trip details. "
+        "Repeat the details exactly and address the person informally."
+    ),
+    "it": (
+        "Formula dai seguenti dati di viaggio un breve testo cordiale. "
+        "Riporta esattamente i dati di viaggio e rivolgiti alla persona "
+        "in modo informale."
+    ),
+}
+
 
 def parse_query_chatgpt(text: str) -> dict:
     """Parse the query text via the OpenAI ChatGPT API."""
@@ -138,15 +156,24 @@ def reformat_summary(text: str) -> str:
     return content
 
 
-def narrative_trip_summary(result: dict) -> str:
-    """Return a friendly ChatGPT summary for a trip search result."""
+def narrative_trip_summary(result: dict, lang: str = "de") -> str:
+    """Return a friendly ChatGPT summary for a trip search result.
+
+    Parameters
+    ----------
+    result: dict
+        Parsed trip search response.
+    lang: str, optional
+        Language code for the summary. Defaults to ``"de"``.
+    """
     from .summaries import format_search_result
 
     api_key = OPENAI_API_KEY
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
 
-    legs_text = format_search_result(result, legs_only=True)
+    legs_text = format_search_result(result, legs_only=True, lang=lang)
+    prompt = _PROMPTS.get(lang, _PROMPTS["en"])
 
     headers = {
         "Authorization": f"Bearer {api_key}",
@@ -156,13 +183,7 @@ def narrative_trip_summary(result: dict) -> str:
         "model": "gpt-3.5-turbo",
         "temperature": 0,
         "messages": [
-            {
-                "role": "system",
-                "content": (
-                    "Formuliere aus den folgenden Verbindungsdaten einen kurzen und freundlichen Text. "
-                    "Gib die Verbindungsdaten exakt wieder und sprich die Person in Du-Form an."
-                ),
-            },
+            {"role": "system", "content": prompt},
             {"role": "user", "content": legs_text},
         ],
     }

--- a/src/cli.py
+++ b/src/cli.py
@@ -67,7 +67,8 @@ def run_search(query: str, output_format: str = "legs", debug: bool = False, use
         print(json.dumps(response, ensure_ascii=False, indent=2))
     else:
         if use_chatgpt:
-            text = chatgpt_helper.narrative_trip_summary(response)
+            lang = params.get("lang") or nlp_parser.detect_language(query)
+            text = chatgpt_helper.narrative_trip_summary(response, lang=lang)
         elif output_format == "legs":
             text = format_search_result(response, legs_only=True)
         else:

--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -30,7 +30,7 @@ def get_stop_code(query: str, lang: Optional[str] = None) -> str:
         "locationServerActive": 1,
         "outputEncoding": "UTF-8",
     }
-    if lang in ("de", "it"):
+    if lang in ("de", "it", "en"):
         params["language"] = lang
 
     logger.debug("Requesting stop code for '%s'", query)
@@ -123,7 +123,7 @@ def search_efa(params: Dict[str, Any]) -> Dict[str, Any]:
         "odvMacro": "true",
         "outputEncoding": "UTF-8",
     }
-    if lang in ("de", "it"):
+    if lang in ("de", "it", "en"):
         efa_params["language"] = lang
 
     time = params.get("time")
@@ -160,7 +160,7 @@ def dm_request(stop_name: str, limit: int = 10, lang: Optional[str] = None) -> D
         "odvMacro": "true",
         "outputEncoding": "UTF-8",
     }
-    if lang in ("de", "it"):
+    if lang in ("de", "it", "en"):
         params["language"] = lang
 
     logger.debug("DM request params: %s", params)
@@ -188,7 +188,7 @@ def stopfinder_request(query: str, lang: Optional[str] = None) -> Dict[str, Any]
         "locationServerActive": 1,
         "outputEncoding": "UTF-8",
     }
-    if lang in ("de", "it"):
+    if lang in ("de", "it", "en"):
         params["language"] = lang
     logger.info("Stop finder for query '%s'", query)
     logger.debug("StopFinder params: %s", params)

--- a/src/main.py
+++ b/src/main.py
@@ -42,9 +42,9 @@ def search(req: SearchRequest, format: Optional[str] = None, chatgpt: bool = Fal
     logger.debug("/search result: %s", result)
     if format == "json":
         return result
-    lang = params.get("lang", "de")
+    lang = params.get("lang") or nlp_parser.detect_language(req.text)
     if chatgpt:
-        text = chatgpt_helper.narrative_trip_summary(result)
+        text = chatgpt_helper.narrative_trip_summary(result, lang=lang)
         return PlainTextResponse(text)
     if format == "text":
         text = format_search_result(result, legs_only=False, lang=lang)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,26 +35,28 @@ def test_run_search_legs(mock_parse, mock_search, mock_format, capsys):
 
 
 @patch('src.cli.chatgpt_helper.narrative_trip_summary', return_value='better')
+@patch('src.cli.nlp_parser.detect_language', return_value='de')
 @patch('src.cli.efa_api.search_efa', return_value={'ok': True})
 @patch('src.cli.nlp_parser.parse_query')
 @patch('src.cli.chatgpt_helper.parse_query_chatgpt', return_value={'from_stop': 'A', 'to_stop': 'B'})
-def test_run_search_chatgpt(mock_parse_gpt, mock_parse, mock_search, mock_narrative, capsys):
+def test_run_search_chatgpt(mock_parse_gpt, mock_parse, mock_search, mock_detect, mock_narrative, capsys):
     cli.run_search('foo', output_format='legs', use_chatgpt=True)
     captured = capsys.readouterr()
     assert captured.out.strip() == 'better'
     mock_parse_gpt.assert_called_once_with('foo')
     mock_parse.assert_not_called()
-    mock_narrative.assert_called_once_with({'ok': True})
+    mock_narrative.assert_called_once_with({'ok': True}, lang='de')
 
 
 @patch('src.cli.chatgpt_helper.narrative_trip_summary', return_value='better')
+@patch('src.cli.nlp_parser.detect_language', return_value='de')
 @patch('src.cli.efa_api.search_efa', return_value={'ok': True})
 @patch('src.cli.nlp_parser.parse_query', return_value={'from_stop': 'A', 'to_stop': 'B'})
 @patch('src.cli.chatgpt_helper.parse_query_chatgpt', return_value={})
-def test_run_search_chatgpt_fallback(mock_parse_gpt, mock_parse, mock_search, mock_narrative, capsys):
+def test_run_search_chatgpt_fallback(mock_parse_gpt, mock_parse, mock_search, mock_detect, mock_narrative, capsys):
     cli.run_search('foo', output_format='legs', use_chatgpt=True)
     captured = capsys.readouterr()
     assert captured.out.strip() == 'better'
     mock_parse_gpt.assert_called_once_with('foo')
     mock_parse.assert_called_once_with('foo')
-    mock_narrative.assert_called_once_with({'ok': True})
+    mock_narrative.assert_called_once_with({'ok': True}, lang='de')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,9 +21,10 @@ def test_search_endpoint(mock_parse_query, mock_search_efa):
 
 
 @patch('src.main.format_search_result', return_value='summary')
+@patch('src.main.nlp_parser.detect_language', return_value='de')
 @patch('src.main.efa_api.search_efa')
 @patch('src.main.nlp_parser.parse_query')
-def test_search_endpoint_text(mock_parse_query, mock_search_efa, mock_format):
+def test_search_endpoint_text(mock_parse_query, mock_search_efa, mock_detect, mock_format):
     mock_parse_query.return_value = {'from_stop': 'A', 'to_stop': 'B'}
     mock_search_efa.return_value = {'dummy': True}
     client = TestClient(app)
@@ -34,9 +35,10 @@ def test_search_endpoint_text(mock_parse_query, mock_search_efa, mock_format):
 
 
 @patch('src.main.format_search_result', return_value='legs')
+@patch('src.main.nlp_parser.detect_language', return_value='de')
 @patch('src.main.efa_api.search_efa')
 @patch('src.main.nlp_parser.parse_query')
-def test_search_endpoint_default(mock_parse_query, mock_search_efa, mock_format):
+def test_search_endpoint_default(mock_parse_query, mock_search_efa, mock_detect, mock_format):
     mock_parse_query.return_value = {'from_stop': 'A', 'to_stop': 'B'}
     mock_search_efa.return_value = {'dummy': True}
     client = TestClient(app)
@@ -47,10 +49,11 @@ def test_search_endpoint_default(mock_parse_query, mock_search_efa, mock_format)
 
 
 @patch('src.main.chatgpt_helper.narrative_trip_summary', return_value='better')
+@patch('src.main.nlp_parser.detect_language', return_value='de')
 @patch('src.main.efa_api.search_efa')
 @patch('src.main.nlp_parser.parse_query')
 @patch('src.main.chatgpt_helper.parse_query_chatgpt', return_value={'from_stop': 'A', 'to_stop': 'B'})
-def test_search_endpoint_chatgpt(mock_parse_gpt, mock_parse_query, mock_search_efa, mock_narrative):
+def test_search_endpoint_chatgpt(mock_parse_gpt, mock_parse_query, mock_search_efa, mock_detect, mock_narrative):
     mock_search_efa.return_value = {'dummy': True}
     client = TestClient(app)
     response = client.post('/search?chatgpt=true', json={'text': 'foo'})
@@ -58,7 +61,7 @@ def test_search_endpoint_chatgpt(mock_parse_gpt, mock_parse_query, mock_search_e
     assert response.text == 'better'
     mock_parse_gpt.assert_called_once_with('foo')
     mock_parse_query.assert_not_called()
-    mock_narrative.assert_called_once_with({'dummy': True})
+    mock_narrative.assert_called_once_with({'dummy': True}, lang='de')
 
 
 @patch('src.main.efa_api.search_efa')


### PR DESCRIPTION
## Summary
- use `language` parameter for English in EFA API wrappers
- add language-specific prompts for ChatGPT summaries
- detect user language for ChatGPT search responses
- pass language from CLI to ChatGPT summaries
- adjust tests for updated function signatures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867eb0d85948321be0073502f4286f8