### PR TITLE
Add ChatGPT plugin files

### DIFF
--- a/.well-known/ai-plugin.json
+++ b/.well-known/ai-plugin.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "v1",
+  "name_for_human": "Suedtirolmobil Assistant",
+  "name_for_model": "suedtirolmobil",
+  "description_for_human": "Query South Tyrol public transport data.",
+  "description_for_model": "Search for trips, get departures and stop suggestions via the Suedtirolmobil API.",
+  "auth": {
+    "type": "none"
+  },
+  "api": {
+    "type": "openapi",
+    "url": "http://localhost:8000/.well-known/openapi.yaml"
+  },
+  "logo_url": "https://example.com/logo.png",
+  "contact_email": "support@example.com",
+  "legal_info_url": "https://example.com/legal"
+}

--- a/.well-known/openapi.yaml
+++ b/.well-known/openapi.yaml
@@ -1,0 +1,116 @@
+openapi: 3.0.1
+info:
+  title: suedtirolmobilAI
+  description: API for public transport queries.
+  version: "1.0"
+servers:
+  - url: http://localhost:8000
+paths:
+  /search:
+    post:
+      summary: Search for a trip
+      operationId: searchTrip
+      parameters:
+        - in: query
+          name: format
+          schema:
+            type: string
+            enum: [text, json]
+        - in: query
+          name: chatgpt
+          schema:
+            type: boolean
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+              required:
+                - text
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+            text/plain:
+              schema:
+                type: string
+  /departures:
+    post:
+      summary: Upcoming departures for a stop
+      operationId: listDepartures
+      parameters:
+        - in: query
+          name: format
+          schema:
+            type: string
+            enum: [text, json]
+        - in: query
+          name: chatgpt
+          schema:
+            type: boolean
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                stop:
+                  type: string
+                limit:
+                  type: integer
+                  default: 10
+              required:
+                - stop
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+            text/plain:
+              schema:
+                type: string
+  /stops:
+    post:
+      summary: Suggest stop names
+      operationId: listStops
+      parameters:
+        - in: query
+          name: format
+          schema:
+            type: string
+            enum: [text, json]
+        - in: query
+          name: chatgpt
+          schema:
+            type: boolean
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                query:
+                  type: string
+              required:
+                - query
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+            text/plain:
+              schema:
+                type: string

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ transport and forwards them to a Mentz‑EFA backend.
 - Automatically decide between trip search, departures and stop search
   based on the entered text.
 - Optional ChatGPT summaries for nicer text output.
+- ChatGPT plugin manifest for webhook integration.
 - Command line client for quick access.
 - Simple Telegram bot for chat interaction.
 - Configurable Mentz‑EFA base URL via `EFA_BASE_URL`.
@@ -145,6 +146,12 @@ OPENAI_API_KEY=sk-... python -m src.cli search "Bozen nach Meran" --chatgpt
 # or for the server
 OPENAI_API_KEY=sk-... uvicorn src.main:app --host 0.0.0.0 --reload
 ```
+
+## ChatGPT plugin
+The repository includes a plugin manifest and OpenAPI file in the
+`.well-known/` directory. When the server is running they are served under
+`/.well-known/ai-plugin.json` and `/.well-known/openapi.yaml` for easy
+integration with ChatGPT.
 
 ## Telegram bot
 Forward messages to the API using the example bot:

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,8 @@
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import PlainTextResponse
+from fastapi.staticfiles import StaticFiles
+from pathlib import Path
 from pydantic import BaseModel
 from typing import Optional
 import logging
@@ -17,6 +19,11 @@ from .logging_utils import setup_logging
 logger = logging.getLogger(__name__)
 
 app = FastAPI()
+app.mount(
+    "/.well-known",
+    StaticFiles(directory=Path(__file__).resolve().parent.parent / ".well-known"),
+    name="well-known",
+)
 
 class SearchRequest(BaseModel):
     text: str


### PR DESCRIPTION
## Summary
- add ChatGPT plugin manifest and OpenAPI description under `.well-known/`
- serve `.well-known` via FastAPI
- document plugin usage in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e47ecd28832190753c2c92069c1a