### PR TITLE
Add venv activation to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+# Activate existing virtual environment if present
+if [ -f "venv/bin/activate" ]; then
+    source venv/bin/activate
+fi
 
 # Ensure Python 3.8+ and build tools (for spaCy dependencies)
 PYTHON_CMD=python3


### PR DESCRIPTION
## Summary
- activate an existing virtual environment at the start of `install.sh`
- keep activating it again after creating the venv

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867ededb52c8321904570876a201ad6