### PR TITLE
Display parsed query in CLI

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -14,6 +14,23 @@ from .summaries import (
 logger = logging.getLogger(__name__)
 
 
+def _describe_search(params: dict) -> str:
+    """Return a short human readable description of search parameters."""
+    from_stop = params.get("from_stop")
+    to_stop = params.get("to_stop")
+    time = params.get("time")
+    parts = []
+    if from_stop and to_stop:
+        parts.append(f"Von {from_stop} nach {to_stop}")
+    elif from_stop:
+        parts.append(f"Von {from_stop}")
+    elif to_stop:
+        parts.append(f"Nach {to_stop}")
+    if time:
+        parts.append(f"um {time} Uhr")
+    return " ".join(parts)
+
+
 def run_search(query: str, output_format: str = "legs", debug: bool = False, use_chatgpt: bool = False) -> None:
     """Run a search for the given natural language query.
 
@@ -43,6 +60,10 @@ def run_search(query: str, output_format: str = "legs", debug: bool = False, use
     if not params:
         logger.warning("No parameters extracted from the query.")
         return
+
+    desc = _describe_search(params)
+    if desc:
+        print(desc)
 
     logger.info("Determining results...")
     try:
@@ -96,6 +117,7 @@ def run_departures(stop: str, output_format: str = "text", debug: bool = False, 
         logger.error("Fehler bei der Abfrage: %s", exc)
         return
 
+    print(f"Abfahrten {stop}")
     logger.info("Suche wird gestartet...")
     logger.info("Ergebnisse gefunden.")
     if output_format == "json" and not debug:
@@ -130,6 +152,8 @@ def run_stop_finder(query: str, output_format: str = "text", debug: bool = False
     except Exception as exc:
         logger.error("Error during request: %s", exc)
         return
+
+    print(f"Treffer f\u00fcr Suchbegriff: {query}")
     if output_format == "json" and not debug:
         output_format = "text"
     if output_format == "json":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,9 @@ from src import cli
 def test_run_search_text(mock_parse, mock_search, mock_format, capsys):
     cli.run_search('foo', output_format='text')
     captured = capsys.readouterr()
-    assert captured.out.strip() == 'summary'
+    lines = captured.out.strip().splitlines()
+    assert lines[0] == 'Von A nach B'
+    assert lines[1] == 'summary'
     mock_format.assert_called_once_with({'ok': True})
 
 @patch('src.cli.efa_api.search_efa', return_value={'foo': 'bar'})
@@ -21,7 +23,10 @@ def test_run_search_text(mock_parse, mock_search, mock_format, capsys):
 def test_run_search_json(mock_parse, mock_search, capsys):
     cli.run_search('foo', output_format='json', debug=True)
     captured = capsys.readouterr()
-    assert json.loads(captured.out) == {'foo': 'bar'}
+    lines = captured.out.splitlines()
+    assert lines[0] == 'Von A'
+    json_text = '\n'.join(lines[1:])
+    assert json.loads(json_text) == {'foo': 'bar'}
 
 
 @patch('src.cli.format_search_result', return_value='legs')
@@ -30,7 +35,9 @@ def test_run_search_json(mock_parse, mock_search, capsys):
 def test_run_search_legs(mock_parse, mock_search, mock_format, capsys):
     cli.run_search('foo', output_format='legs')
     captured = capsys.readouterr()
-    assert captured.out.strip() == 'legs'
+    lines = captured.out.strip().splitlines()
+    assert lines[0] == 'Von A nach B'
+    assert lines[1] == 'legs'
     mock_format.assert_called_once_with({'ok': True}, legs_only=True)
 
 
@@ -42,7 +49,9 @@ def test_run_search_legs(mock_parse, mock_search, mock_format, capsys):
 def test_run_search_chatgpt(mock_parse_gpt, mock_parse, mock_search, mock_detect, mock_narrative, capsys):
     cli.run_search('foo', output_format='legs', use_chatgpt=True)
     captured = capsys.readouterr()
-    assert captured.out.strip() == 'better'
+    lines = captured.out.strip().splitlines()
+    assert lines[0] == 'Von A nach B'
+    assert lines[1] == 'better'
     mock_parse_gpt.assert_called_once_with('foo')
     mock_parse.assert_not_called()
     mock_narrative.assert_called_once_with({'ok': True}, lang='de')
@@ -56,7 +65,9 @@ def test_run_search_chatgpt(mock_parse_gpt, mock_parse, mock_search, mock_detect
 def test_run_search_chatgpt_fallback(mock_parse_gpt, mock_parse, mock_search, mock_detect, mock_narrative, capsys):
     cli.run_search('foo', output_format='legs', use_chatgpt=True)
     captured = capsys.readouterr()
-    assert captured.out.strip() == 'better'
+    lines = captured.out.strip().splitlines()
+    assert lines[0] == 'Von A nach B'
+    assert lines[1] == 'better'
     mock_parse_gpt.assert_called_once_with('foo')
     mock_parse.assert_called_once_with('foo')
     mock_narrative.assert_called_once_with({'ok': True}, lang='de')


### PR DESCRIPTION
## Summary
- show an interpreted query summary before printing results
- update CLI tests for new output

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a8d375040832187ffea08a2fab241