### PR TITLE
Fix plugin server domain

### DIFF
--- a/.well-known/openapi.yaml
+++ b/.well-known/openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: API for public transport queries.
   version: "1.0"
 servers:
-  - url: http://localhost:8000
+  - url: https://suedtirolmobilai.duckdns.org
 paths:
   /search:
     post:
@@ -38,6 +38,10 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  data:
+                    description: Response payload
+                    type: object
                 additionalProperties: true
             text/plain:
               schema:
@@ -77,6 +81,10 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  data:
+                    description: Response payload
+                    type: object
                 additionalProperties: true
             text/plain:
               schema:
@@ -113,6 +121,10 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  data:
+                    description: Response payload
+                    type: object
                 additionalProperties: true
             text/plain:
               schema:


### PR DESCRIPTION
## Summary
- host OpenAPI under the correct plugin domain
- provide basic response properties in the OpenAPI spec

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd37471f083219e72e3899ffd2246