### PR TITLE
Add chat loop support to Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ transport and forwards them to a Mentz‑EFA backend.
 - Optional ChatGPT summaries for nicer text output.
 - ChatGPT plugin manifest for webhook integration.
 - Command line client for quick access.
-- Simple Telegram bot for chat interaction.
+- Simple Telegram bot for chat interaction, including a `/loop` mode.
 - Interactive console chat loop using ChatGPT.
 - Configurable Mentz‑EFA base URL via `EFA_BASE_URL`.
 
@@ -174,6 +174,9 @@ defaults to the value of the `API_URL` environment variable or
 
 When selecting a command from the bot's keyboard without additional text,
 the bot will ask for the required input before sending the request.
+
+Use `/loop` to start a conversational mode that interprets free text via the
+`/parse`, `/trip` and `/stops` API endpoints. Send `/cancel` to exit the loop.
 
 ## Console chat loop
 Start an interactive session on the console using ChatGPT to parse requests and format results.

--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,7 @@ from fastapi.responses import PlainTextResponse
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, Dict, Any
 import logging
 
 from . import nlp_parser, efa_api, chatgpt_helper
@@ -35,6 +35,21 @@ class DMRequest(BaseModel):
 
 class StopFinderRequest(BaseModel):
     query: str
+
+
+class ParseRequest(BaseModel):
+    """Input model for the /parse endpoint."""
+
+    text: str
+
+
+class TripRequest(BaseModel):
+    """Input model for the /trip endpoint."""
+
+    from_stop: str
+    to_stop: str
+    time: Optional[str] = None
+    lang: Optional[str] = None
 
 @app.post("/search")
 def search(req: SearchRequest, format: Optional[str] = None, chatgpt: bool = False):
@@ -101,6 +116,44 @@ def stops(req: StopFinderRequest, format: str = "json", chatgpt: bool = False):
             text = chatgpt_helper.reformat_summary(text)
         return PlainTextResponse(text)
     return result
+
+
+@app.post("/parse")
+def parse(req: ParseRequest):
+    """Parse a user request via the language model."""
+
+    logger.info("/parse text='%s'", req.text)
+    info = chatgpt_helper.parse_request_llm(req.text)
+    if not info:
+        raise HTTPException(status_code=400, detail="Parse failed")
+    return info
+
+
+@app.post("/trip")
+def trip(req: TripRequest, format: Optional[str] = None, chatgpt: bool = False):
+    """Return trip results for explicit parameters."""
+
+    params: Dict[str, Any] = {
+        "from_stop": req.from_stop,
+        "to_stop": req.to_stop,
+    }
+    if req.time:
+        params["time"] = req.time
+    if req.lang:
+        params["lang"] = req.lang
+    logger.info("/trip params: %s", params)
+    result = efa_api.search_efa(params)
+    if format == "json":
+        return result
+    lang = req.lang or nlp_parser.detect_language(req.from_stop)
+    if chatgpt:
+        text = chatgpt_helper.format_trip_response_llm(result, lang=lang)
+        return PlainTextResponse(text)
+    if format == "text":
+        text = format_search_result(result, legs_only=False, lang=lang)
+        return PlainTextResponse(text)
+    text = format_search_result(result, legs_only=True, lang=lang)
+    return PlainTextResponse(text)
 
 # Run via ``python -m src.main`` for debugging without auto-reload.
 if __name__ == "__main__" and __package__:

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -31,7 +31,7 @@ BOT_TOKEN = TELEGRAM_TOKEN
 USE_CHATGPT = False
 
 # Conversation states for interactive commands
-SEARCH, DEPARTURES = range(2)
+SEARCH, DEPARTURES, LOOP = range(3)
 
 
 def parse_args(args=None):
@@ -145,7 +145,7 @@ async def handle_text(update, context):
 
 async def cmd_start(update, context):
     """Send a welcome message and show the command keyboard."""
-    keyboard = [["/search", "/departures", "/stops"]]
+    keyboard = [["/search", "/departures", "/stops", "/loop"]]
     markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
     await update.message.reply_text(
         "Welcome! Send me a request or choose a command.", reply_markup=markup
@@ -233,6 +233,71 @@ async def cmd_stops(update, context):
         await update.message.reply_text(f"Request failed: {exc}")
 
 
+async def cmd_loop(update, context):
+    """Enter continuous chat loop mode."""
+
+    await update.message.reply_text("Loop started. Send /cancel to stop.")
+    return LOOP
+
+
+async def handle_loop(update, context):
+    """Process a message in loop mode."""
+
+    text = update.message.text.strip()
+    try:
+        resp = requests.post(f"{API_URL}/parse", json={"text": text})
+        info = resp.json() if resp.status_code == 200 else {}
+    except Exception as exc:
+        await update.message.reply_text(f"Parse failed: {exc}")
+        return LOOP
+
+    req_type = info.get("type")
+    if req_type in {"trip", "departure"}:
+        params = {}
+        if info.get("from"):
+            params["from_stop"] = info["from"]
+        if info.get("to"):
+            params["to_stop"] = info["to"]
+        if info.get("datetime"):
+            params["time"] = info["datetime"].split("T")[-1][:5]
+        if info.get("language"):
+            params["lang"] = info["language"]
+        url = f"{API_URL}/trip?format=text"
+        if USE_CHATGPT:
+            url += "&chatgpt=true"
+        try:
+            resp = requests.post(url, json=params)
+            if resp.status_code == 200:
+                await update.message.reply_text(resp.text)
+            else:
+                await update.message.reply_text(f"Error: {resp.text}")
+        except Exception as exc:
+            await update.message.reply_text(f"Request failed: {exc}")
+    elif req_type == "stop":
+        query = info.get("from") or info.get("to") or text
+        url = f"{API_URL}/stops?format=text"
+        if USE_CHATGPT:
+            url += "&chatgpt=true"
+        try:
+            resp = requests.post(url, json={"query": query})
+            if resp.status_code == 200:
+                await update.message.reply_text(resp.text)
+            else:
+                await update.message.reply_text(f"Error: {resp.text}")
+        except Exception as exc:
+            await update.message.reply_text(f"Request failed: {exc}")
+    else:
+        await update.message.reply_text("Sorry, I could not understand your request.")
+    return LOOP
+
+
+async def cancel_loop(update, context):
+    """Exit loop mode."""
+
+    await update.message.reply_text("Loop ended.")
+    return ConversationHandler.END
+
+
 async def cmd_reset(update, context):
     """Clear the stored conversation state."""
     context.user_data.clear()
@@ -289,8 +354,18 @@ def main() -> None:
             },
             fallbacks=[],
         )
+        loop_conv = ConversationHandler(
+            entry_points=[CommandHandler("loop", cmd_loop)],
+            states={
+                LOOP: [
+                    MessageHandler(filters.TEXT & ~filters.COMMAND, handle_loop)
+                ]
+            },
+            fallbacks=[CommandHandler("cancel", cancel_loop)],
+        )
         application.add_handler(search_conv)
         application.add_handler(depart_conv)
+        application.add_handler(loop_conv)
         application.add_handler(CommandHandler("stops", cmd_stops))
         application.add_handler(CommandHandler("reset", cmd_reset))
         application.add_handler(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -148,3 +148,25 @@ def test_stops_endpoint_chatgpt(mock_stopfinder_request, mock_format, mock_detec
     assert response.text == 'better stops'
     mock_format.assert_called_once_with({'foo': 'bar'}, lang='de')
     mock_reformat.assert_called_once_with('stops')
+
+
+@patch('src.main.chatgpt_helper.parse_request_llm', return_value={'type': 'trip'})
+def test_parse_endpoint(mock_parse):
+    client = TestClient(app)
+    response = client.post('/parse', json={'text': 'foo'})
+    assert response.status_code == 200
+    assert response.json() == {'type': 'trip'}
+    mock_parse.assert_called_once_with('foo')
+
+
+@patch('src.main.format_search_result', return_value='legs')
+@patch('src.main.efa_api.search_efa', return_value={'ok': True})
+@patch('src.main.nlp_parser.detect_language', return_value='de')
+def test_trip_endpoint(mock_detect, mock_search, mock_format):
+    client = TestClient(app)
+    payload = {'from_stop': 'A', 'to_stop': 'B'}
+    response = client.post('/trip', json=payload)
+    assert response.status_code == 200
+    assert response.text == 'legs'
+    mock_search.assert_called_once_with(payload)
+    mock_format.assert_called_once_with({'ok': True}, legs_only=True, lang='de')


### PR DESCRIPTION
## Summary
- support `/loop` command in Telegram bot
- expose `/parse` and `/trip` API endpoints
- update README instructions
- test parse and trip endpoints

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce895cfa4832183ae826a78171237