### PR TITLE
Implement simple chat parser and EFA API wrapper

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -1,0 +1,27 @@
+"""Simple console chat loop."""
+
+from . import parser, efa_api
+
+
+def main() -> None:
+    """Run console chat."""
+    while True:
+        try:
+            text = input("> ").strip()
+        except EOFError:
+            break
+        if not text:
+            continue
+        q = parser.parse(text)
+        if q.type == "trip" and q.from_location and q.to_location:
+            data = efa_api.trip_request(q.from_location, q.to_location, q.datetime)
+            print(data)
+        elif q.type == "departure" and q.from_location:
+            data = efa_api.departure_monitor(q.from_location)
+            print(data)
+        else:
+            print("Couldn't understand query")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -1,0 +1,51 @@
+"""Simple wrapper for the Mentz EFA API."""
+
+from typing import Optional, Dict, Any
+import os
+import requests
+
+BASE_URL = os.getenv("EFA_BASE_URL", "https://efa.sta.bz.it/apb")
+
+
+def trip_request(origin: str, destination: str, datetime: Optional[str] = None) -> Dict[str, Any]:
+    """Request a trip from origin to destination."""
+    params = {
+        "name_origin": origin,
+        "type_origin": "any",
+        "name_destination": destination,
+        "type_destination": "any",
+        "outputFormat": "JSON",
+    }
+    if datetime:
+        date, time = datetime.split("T")
+        params["itdDate"] = date
+        params["itdTime"] = time
+    response = requests.get(f"{BASE_URL}/XML_TRIP_REQUEST2", params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def departure_monitor(stop: str, limit: int = 5) -> Dict[str, Any]:
+    """Return upcoming departures for a stop."""
+    params = {
+        "name_dm": stop,
+        "type_dm": "stop",
+        "mode": "direct",
+        "limit": limit,
+        "outputFormat": "JSON",
+    }
+    response = requests.get(f"{BASE_URL}/XML_DM_REQUEST", params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def stop_finder(query: str) -> Dict[str, Any]:
+    """Find stop name suggestions for a query."""
+    params = {
+        "name_sf": query,
+        "odvSugMacro": "true",
+        "outputFormat": "JSON",
+    }
+    response = requests.get(f"{BASE_URL}/XML_STOPFINDER_REQUEST", params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()

--- a/src/parser.py
+++ b/src/parser.py
@@ -1,0 +1,37 @@
+"""Very small rule-based parser for transport queries."""
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Query:
+    """Parsed query information."""
+
+    type: str
+    from_location: Optional[str] = None
+    to_location: Optional[str] = None
+    datetime: Optional[str] = None
+    line: Optional[str] = None
+
+
+TRIP_RE = re.compile(r"von (?P<from>\w+) nach (?P<to>\w+)(?: um (?P<time>\d{1,2}:\d{2}))?", re.I)
+DEPT_RE = re.compile(r"abfahrten? (?P<stop>\w+)", re.I)
+
+
+def parse(text: str) -> Query:
+    """Parse a German language query."""
+    match = TRIP_RE.search(text)
+    if match:
+        dt = match.group("time")
+        iso = None
+        if dt:
+            iso = f"2025-01-01T{dt}"
+        return Query("trip", match.group("from"), match.group("to"), iso)
+
+    match = DEPT_RE.search(text)
+    if match:
+        return Query("departure", from_location=match.group("stop"))
+
+    return Query("unknown")


### PR DESCRIPTION
## Summary
- add minimal Python package `src` with EFA API wrapper
- implement a tiny rule-based parser
- provide a console chat loop for manual testing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d03ab4f988321bff5ca26cbd6d87e