### PR TITLE
Fix env loading and global variable order

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,10 @@
+"""Project package setup."""
+
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+_dotenv_path = Path(__file__).resolve().parent.parent / ".env"
+if _dotenv_path.exists():
+    load_dotenv(_dotenv_path)
+

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -102,12 +102,12 @@ def run_bot(token: str, start_server: bool) -> None:
 
 def main() -> None:
     """Parse arguments and run the bot."""
+    global API_URL
     parser = argparse.ArgumentParser()
     parser.add_argument("--api-url", default=API_URL, help="API endpoint")
     parser.add_argument("--start-server", action="store_true", help="start API with uvicorn")
     parser.add_argument("--token", default=TOKEN, help="Telegram bot token")
     args = parser.parse_args()
-    global API_URL
     API_URL = args.api_url
     if not args.token:
         parser.error("Telegram token not provided")


### PR DESCRIPTION
## Summary
- load environment variables from `.env` at package import
- fix `API_URL` global variable initialization in the Telegram bot

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d0be8845883218ac11c5ebdbb8874