### PR TITLE
Remove chatgpt flag

### DIFF
--- a/.well-known/openapi.yaml
+++ b/.well-known/openapi.yaml
@@ -16,10 +16,6 @@ paths:
           schema:
             type: string
             enum: [text, json]
-        - in: query
-          name: chatgpt
-          schema:
-            type: boolean
       requestBody:
         required: true
         content:
@@ -56,10 +52,6 @@ paths:
           schema:
             type: string
             enum: [text, json]
-        - in: query
-          name: chatgpt
-          schema:
-            type: boolean
       requestBody:
         required: true
         content:
@@ -99,10 +91,6 @@ paths:
           schema:
             type: string
             enum: [text, json]
-        - in: query
-          name: chatgpt
-          schema:
-            type: boolean
       requestBody:
         required: true
         content:

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ curl -X POST http://localhost:8000/stops \
      -H 'Content-Type: application/json' \
      -d '{"query": "Brixen"}'
 ```
-Append `?format=text` or `?format=json` to change the response and use
-`chatgpt=true` for ChatGPT summaries.
+Append `?format=text` or `?format=json` to change the response. ChatGPT
+summaries are enabled automatically when `OPENAI_API_KEY` is set.
 
 ## ChatGPT plugin
 The repository includes a plugin manifest and OpenAPI file in the

--- a/src/main.py
+++ b/src/main.py
@@ -30,7 +30,7 @@ class StopsRequest(BaseModel):
 
 
 @app.post("/search")
-def search(body: SearchRequest, format: str = Query("json"), chatgpt: bool = False) -> Any:
+def search(body: SearchRequest, format: str = Query("json")) -> Any:
     """Parse a text query for a trip and return EFA results."""
     q = parser.parse(body.text)
     if q.type != "trip" or not q.from_location or not q.to_location:
@@ -39,21 +39,22 @@ def search(body: SearchRequest, format: str = Query("json"), chatgpt: bool = Fal
         except Exception as exc:  # pragma: no cover - no tests
             raise HTTPException(status_code=400, detail=str(exc))
     data: Dict[str, Any] = efa_api.trip_request(q.from_location, q.to_location, q.datetime)
-    if chatgpt:
+    try:
         text = llm_formatter.format_trip(data, language=q.language or "de")
         return text if format == "text" else {"data": text}
-    return data if format == "text" else {"data": data}
+    except Exception as exc:  # pragma: no cover - no tests
+        raise HTTPException(status_code=500, detail=str(exc))
 
 
 @app.post("/departures")
-def departures(body: DeparturesRequest, format: str = Query("json"), chatgpt: bool = False) -> Any:
+def departures(body: DeparturesRequest, format: str = Query("json")) -> Any:
     """Return upcoming departures for a stop."""
     data = efa_api.departure_monitor(body.stop, body.limit)
     return data if format == "text" else {"data": data}
 
 
 @app.post("/stops")
-def stops(body: StopsRequest, format: str = Query("json"), chatgpt: bool = False) -> Any:
+def stops(body: StopsRequest, format: str = Query("json")) -> Any:
     """Return stop name suggestions."""
     data = efa_api.stop_finder(body.query)
     return data if format == "text" else {"data": data}


### PR DESCRIPTION
## Summary
- default to ChatGPT formatting for trip search
- drop the `chatgpt` query parameter from API and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d10a1621c8321b736af0d18ff077c