### PR TITLE
Improve telegram bot formatting and add debug mode

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -38,6 +38,19 @@ def search(body: SearchRequest, format: str = Query("json"), chatgpt: bool = Fal
             q = llm_parser.parse_llm(body.text)
         except Exception as exc:  # pragma: no cover - no tests
             raise HTTPException(status_code=400, detail=str(exc))
+
+    from_data = efa_api.stop_finder(q.from_location)
+    points = from_data.get("stopFinder", {}).get("points", [])
+    if not points:
+        raise HTTPException(status_code=404, detail="origin not found")
+    q.from_location = points[0].get("name", q.from_location)
+
+    to_data = efa_api.stop_finder(q.to_location)
+    points = to_data.get("stopFinder", {}).get("points", [])
+    if not points:
+        raise HTTPException(status_code=404, detail="destination not found")
+    q.to_location = points[0].get("name", q.to_location)
+
     data: Dict[str, Any] = efa_api.trip_request(q.from_location, q.to_location, q.datetime)
     if chatgpt:
         text = llm_formatter.format_trip(data, language=q.language or "de")
@@ -48,7 +61,12 @@ def search(body: SearchRequest, format: str = Query("json"), chatgpt: bool = Fal
 @app.post("/departures")
 def departures(body: DeparturesRequest, format: str = Query("json"), chatgpt: bool = False) -> Any:
     """Return upcoming departures for a stop."""
-    data = efa_api.departure_monitor(body.stop, body.limit)
+    sf_data = efa_api.stop_finder(body.stop)
+    points = sf_data.get("stopFinder", {}).get("points", [])
+    if not points:
+        raise HTTPException(status_code=404, detail="stop not found")
+    verified = points[0].get("name", body.stop)
+    data = efa_api.departure_monitor(verified, body.limit)
     return data if format == "text" else {"data": data}
 
 

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -2,10 +2,11 @@
 
 import argparse
 import asyncio
+import json
 import logging
 import os
 import threading
-from typing import Dict, Any
+from typing import Dict, Any, List
 
 import requests
 from telegram import Update, KeyboardButton, ReplyKeyboardMarkup
@@ -19,30 +20,41 @@ TOKEN = os.getenv("TELEGRAM_TOKEN")
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+DEBUG = False
+DEBUG_INFO: List[Dict[str, Any]] = []
+
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Send greeting and show command keyboard."""
-    keyboard = [[KeyboardButton("/search"), KeyboardButton("/departures"), KeyboardButton("/stops")]]
+    keyboard = [[KeyboardButton("/search"), KeyboardButton("/departures"), KeyboardButton("/stops"), KeyboardButton("/debug")]]
     await update.message.reply_text(
         "Send a query or choose a command:", reply_markup=ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
     )
 
 
-def call_api(endpoint: str, payload: Dict[str, Any]) -> str:
-    """Send POST request to the API and return response text."""
+def call_api(endpoint: str, payload: Dict[str, Any], *, params: Dict[str, Any] = None, json_response: bool = False) -> Any:
+    """Send POST request to the API and return response."""
+    if DEBUG:
+        logger.debug("Request %s %s %s", endpoint, params, payload)
     try:
-        resp = requests.post(f"{API_URL}{endpoint}", json=payload, timeout=10)
+        resp = requests.post(f"{API_URL}{endpoint}", json=payload, params=params, timeout=10)
     except Exception as exc:  # pragma: no cover - network
         logger.error("Request failed: %s", exc)
+        DEBUG_INFO.append({"endpoint": endpoint, "payload": payload, "error": str(exc)})
         return str(exc)
     if resp.ok:
         try:
             data = resp.json()
-            if isinstance(data, dict) and "data" in data:
-                return str(data["data"])
-            return str(data)
         except ValueError:
-            return resp.text
+            data = resp.text
+        DEBUG_INFO.append({"endpoint": endpoint, "payload": payload, "response": data})
+        if json_response:
+            return data
+        if isinstance(data, dict) and "data" in data:
+            content = data["data"]
+            return content if isinstance(content, str) else json.dumps(content, indent=2, ensure_ascii=False)
+        return data if isinstance(data, str) else json.dumps(data, indent=2, ensure_ascii=False)
+    DEBUG_INFO.append({"endpoint": endpoint, "payload": payload, "status": resp.status_code})
     return f"Error {resp.status_code}: {resp.text}"
 
 
@@ -52,10 +64,22 @@ async def send_reply(update: Update, text: str) -> None:
         await update.message.reply_text(text[i : i + MAX_MESSAGE_LENGTH])
 
 
+async def debug_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send collected debug information."""
+    if not DEBUG_INFO:
+        await send_reply(update, "No debug info available")
+        return
+    await send_reply(update, json.dumps(DEBUG_INFO, indent=2, ensure_ascii=False))
+    DEBUG_INFO.clear()
+
+
 async def handle(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle incoming messages."""
     text = update.message.text.strip()
     state = context.user_data.get("state")
+    if text == "/debug":
+        await debug_command(update, context)
+        return
     if text == "/search":
         context.user_data["state"] = "search"
         await send_reply(update, "Enter trip query:")
@@ -71,22 +95,22 @@ async def handle(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     if state == "search":
         context.user_data.pop("state", None)
-        reply = call_api("/search", {"text": text})
+        reply = call_api("/search", {"text": text}, params={"format": "text", "chatgpt": "true"})
         await send_reply(update, reply)
         return
     if state == "departures":
         context.user_data.pop("state", None)
-        reply = call_api("/departures", {"stop": text})
+        reply = call_api("/departures", {"stop": text}, params={"format": "text"})
         await send_reply(update, reply)
         return
     if state == "stops":
         context.user_data.pop("state", None)
-        reply = call_api("/stops", {"query": text})
+        reply = call_api("/stops", {"query": text}, params={"format": "text"})
         await send_reply(update, reply)
         return
 
     # fallback: try /search
-    reply = call_api("/search", {"text": text})
+    reply = call_api("/search", {"text": text}, params={"format": "text", "chatgpt": "true"})
     await send_reply(update, reply)
 
 
@@ -104,6 +128,7 @@ def run_bot(token: str, start_server: bool) -> None:
 
     application = Application.builder().token(token).build()
     application.add_handler(CommandHandler("start", start))
+    application.add_handler(CommandHandler("debug", debug_command))
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle))
     application.run_polling()
 
@@ -115,10 +140,17 @@ def main() -> None:
     parser.add_argument("--api-url", default=API_URL, help="API endpoint")
     parser.add_argument("--start-server", action="store_true", help="start API with uvicorn")
     parser.add_argument("--token", default=TOKEN, help="Telegram bot token")
+    parser.add_argument("--debug", action="store_true", help="enable debug logging")
     args = parser.parse_args()
     API_URL = args.api_url
     if not args.token:
         parser.error("Telegram token not provided")
+    if args.debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+        global DEBUG
+        DEBUG = True
+        logger.debug("Debug mode active")
+        logger.debug("Args: %s", args)
     run_bot(args.token, args.start_server)
 
 


### PR DESCRIPTION
## Summary
- verify stops with STOP_FINDER before trip or departure requests
- enable optional formatted responses in the telegram bot
- add `--debug` option and `/debug` command for logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d1049f38c83218e5c707f54daee82