### PR TITLE
Add debug output for chat parser

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -1,6 +1,7 @@
 """Simple console chat loop."""
 
 import argparse
+import json
 
 from . import efa_api, parser
 from . import llm_formatter, llm_parser
@@ -11,6 +12,7 @@ def main() -> None:
     argp = argparse.ArgumentParser()
     argp.add_argument("--llm-parser", action="store_true", help="use OpenAI parser")
     argp.add_argument("--llm-format", action="store_true", help="format results with OpenAI")
+    argp.add_argument("--debug", action="store_true", help="show parsed input JSON")
     args = argp.parse_args()
 
     while True:
@@ -28,6 +30,9 @@ def main() -> None:
                 continue
         else:
             q = parser.parse(text)
+
+        if args.debug:
+            print(json.dumps(q.__dict__, indent=2, ensure_ascii=False))
 
         if q.type == "trip" and q.from_location and q.to_location:
             data = efa_api.trip_request(q.from_location, q.to_location, q.datetime)


### PR DESCRIPTION
## Summary
- add a new `--debug` option to the console chat
- print parsed query as JSON when debugging is enabled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d129ca1608321bd426841491fdf8d