### PR TITLE
Use stateless IDs for verified stops

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ transport and forwards them to a EFA (Mentz GmbH) backend.
 - Parse queries in German, English and Italian.
 - Search for public transport connections.
 - Monitor departures for a stop.
+- Use stopfinder results to send stateless stop IDs for trips and departures.
 - Return stop suggestions.
 - Automatically decide between trip search, departures and stop search
   based on the entered text.

--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -7,15 +7,28 @@ import requests
 BASE_URL = os.getenv("EFA_BASE_URL", "https://efa.sta.bz.it/apb")
 
 
-def trip_request(origin: str, destination: str, datetime: Optional[str] = None) -> Dict[str, Any]:
+def trip_request(
+    origin: str,
+    destination: str,
+    datetime: Optional[str] = None,
+    origin_stateless: Optional[str] = None,
+    destination_stateless: Optional[str] = None,
+) -> Dict[str, Any]:
     """Request a trip from origin to destination."""
-    params = {
-        "name_origin": origin,
-        "type_origin": "any",
-        "name_destination": destination,
-        "type_destination": "any",
-        "outputFormat": "JSON",
-    }
+    params = {"outputFormat": "JSON"}
+    if origin_stateless:
+        params["name_origin"] = origin_stateless
+        params["type_origin"] = "stop"
+    else:
+        params["name_origin"] = origin
+        params["type_origin"] = "any"
+
+    if destination_stateless:
+        params["name_destination"] = destination_stateless
+        params["type_destination"] = "stop"
+    else:
+        params["name_destination"] = destination
+        params["type_destination"] = "any"
     if datetime:
         date, time = datetime.split("T")
         params["itdDate"] = date
@@ -25,15 +38,23 @@ def trip_request(origin: str, destination: str, datetime: Optional[str] = None) 
     return response.json()
 
 
-def departure_monitor(stop: str, limit: int = 5) -> Dict[str, Any]:
+def departure_monitor(
+    stop: str,
+    limit: int = 5,
+    stateless: Optional[str] = None,
+) -> Dict[str, Any]:
     """Return upcoming departures for a stop."""
     params = {
-        "name_dm": stop,
-        "type_dm": "stop",
         "mode": "direct",
         "limit": limit,
         "outputFormat": "JSON",
     }
+    if stateless:
+        params["name_dm"] = stateless
+        params["type_dm"] = "stop"
+    else:
+        params["name_dm"] = stop
+        params["type_dm"] = "stop"
     response = requests.get(f"{BASE_URL}/XML_DM_REQUEST", params=params, timeout=10)
     response.raise_for_status()
     return response.json()

--- a/src/main.py
+++ b/src/main.py
@@ -43,15 +43,25 @@ def search(body: SearchRequest, format: str = Query("json")) -> Any:
     points = from_data.get("stopFinder", {}).get("points", [])
     if not points:
         raise HTTPException(status_code=404, detail="origin not found")
-    q.from_location = points[0].get("name", q.from_location)
+    from_point = points[0]
+    q.from_location = from_point.get("name", q.from_location)
+    from_stateless = from_point.get("stateless")
 
     to_data = efa_api.stop_finder(q.to_location)
     points = to_data.get("stopFinder", {}).get("points", [])
     if not points:
         raise HTTPException(status_code=404, detail="destination not found")
-    q.to_location = points[0].get("name", q.to_location)
+    to_point = points[0]
+    q.to_location = to_point.get("name", q.to_location)
+    to_stateless = to_point.get("stateless")
 
-    data: Dict[str, Any] = efa_api.trip_request(q.from_location, q.to_location, q.datetime)
+    data: Dict[str, Any] = efa_api.trip_request(
+        q.from_location,
+        q.to_location,
+        q.datetime,
+        origin_stateless=from_stateless,
+        destination_stateless=to_stateless,
+    )
     try:
         text = llm_formatter.format_trip(data, language=q.language or "de")
         return text if format == "text" else {"data": text}
@@ -66,8 +76,10 @@ def departures(body: DeparturesRequest, format: str = Query("json")) -> Any:
     points = sf_data.get("stopFinder", {}).get("points", [])
     if not points:
         raise HTTPException(status_code=404, detail="stop not found")
-    verified = points[0].get("name", body.stop)
-    data = efa_api.departure_monitor(verified, body.limit)
+    point = points[0]
+    verified = point.get("name", body.stop)
+    stateless = point.get("stateless")
+    data = efa_api.departure_monitor(verified, body.limit, stateless=stateless)
     return data if format == "text" else {"data": data}
 
 


### PR DESCRIPTION
## Summary
- support stateless IDs in `efa_api.trip_request` and `efa_api.departure_monitor`
- forward stateless stop IDs from stopfinder in API endpoints
- document usage of stateless IDs in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d158e4ab48321bd9e6b3fafbd639b