### PR TITLE
Fix missing Query.language attribute

### DIFF
--- a/src/llm_parser.py
+++ b/src/llm_parser.py
@@ -38,4 +38,5 @@ def parse_llm(text: str, model: str = "gpt-3.5-turbo") -> Query:
         to_location=data.get("to"),
         datetime=data.get("datetime"),
         line=None,
+        language=data.get("language"),
     )

--- a/src/parser.py
+++ b/src/parser.py
@@ -14,10 +14,15 @@ class Query:
     to_location: Optional[str] = None
     datetime: Optional[str] = None
     line: Optional[str] = None
+    language: Optional[str] = None
 
 
-TRIP_RE = re.compile(r"von (?P<from>\w+) nach (?P<to>\w+)(?: um (?P<time>\d{1,2}:\d{2}))?", re.I)
+TRIP_RE = re.compile(
+    r"von (?P<from>\w+) nach (?P<to>\w+)(?: um (?P<time>\d{1,2}:\d{2}))?",
+    re.I,
+)
 DEPT_RE = re.compile(r"abfahrten? (?P<stop>\w+)", re.I)
+
 
 
 def parse(text: str) -> Query:
@@ -28,10 +33,16 @@ def parse(text: str) -> Query:
         iso = None
         if dt:
             iso = f"2025-01-01T{dt}"
-        return Query("trip", match.group("from"), match.group("to"), iso)
+        return Query(
+            "trip",
+            match.group("from"),
+            match.group("to"),
+            iso,
+            language="de",
+        )
 
     match = DEPT_RE.search(text)
     if match:
-        return Query("departure", from_location=match.group("stop"))
+        return Query("departure", from_location=match.group("stop"), language="de")
 
-    return Query("unknown")
+    return Query("unknown", language="de")


### PR DESCRIPTION
## Summary
- add `language` field to `Query` dataclass
- set the language when parsing rule-based queries
- return language from OpenAI parser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d173596488321a42a8691f58738d8