### PR TITLE
Reduce data sent to LLM

### DIFF
--- a/src/llm_formatter.py
+++ b/src/llm_formatter.py
@@ -3,7 +3,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 import openai
 
@@ -15,13 +15,94 @@ def load_prompt() -> str:
     return PROMPT_PATH.read_text(encoding="utf-8")
 
 
+def _extract_time(point: Dict[str, Any]) -> Dict[str, Optional[str]]:
+    """Return planned and real time strings from a point."""
+    dt = point.get("dateTime", {})
+    time = None
+    rt_time = None
+    if dt:
+        hour = dt.get("time")
+        if hour:
+            time = hour
+        rt_hour = dt.get("rtTime")
+        if rt_hour:
+            rt_time = rt_hour
+    return {"time": time, "rtTime": rt_time}
+
+
+def extract_trip_info(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return minimal information about a trip."""
+    trip = data.get("trips", {}).get("trip")
+    if not isinstance(trip, dict):
+        return {}
+    result: Dict[str, Any] = {
+        "duration": trip.get("duration"),
+        "interchange": trip.get("interchange"),
+        "legs": [],
+    }
+    legs: List[Dict[str, Any]] = trip.get("legs", [])
+    for leg in legs:
+        points = leg.get("points", [])
+        if len(points) < 2:
+            continue
+        start = points[0]
+        end = points[-1]
+        mode = leg.get("mode", {})
+        leg_info = {
+            "line": mode.get("name"),
+            "number": mode.get("number"),
+            "direction": mode.get("destination"),
+            "origin": start.get("name"),
+            "destination": end.get("name"),
+        }
+        leg_info.update(_extract_time(start))
+        arrival_times = _extract_time(end)
+        leg_info["arrival"] = arrival_times.get("time")
+        leg_info["rtArrival"] = arrival_times.get("rtTime")
+        result["legs"].append(leg_info)
+    return result
+
+
+def extract_departure_info(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return minimal information about upcoming departures."""
+    departures: List[Dict[str, Any]] = []
+    for dep in data.get("departureList", []):
+        line = dep.get("servingLine", {})
+        dt = dep.get("dateTime", {})
+        rt = dep.get("realDateTime", {})
+        time = None
+        rt_time = None
+        if dt:
+            hour = dt.get("hour")
+            minute = dt.get("minute")
+            if hour is not None and minute is not None:
+                time = f"{hour}:{minute.zfill(2)}" if isinstance(minute, str) else f"{hour}:{minute:02d}"
+        if rt:
+            hour = rt.get("hour")
+            minute = rt.get("minute")
+            if hour is not None and minute is not None:
+                rt_time = f"{hour}:{minute.zfill(2)}" if isinstance(minute, str) else f"{hour}:{minute:02d}"
+        departures.append(
+            {
+                "stop": dep.get("stopName"),
+                "line": line.get("name"),
+                "number": line.get("number"),
+                "direction": line.get("direction"),
+                "time": time,
+                "rtTime": rt_time,
+            }
+        )
+    return {"departures": departures}
+
+
 def format_trip(data: Dict[str, Any], language: str = "de", model: str = "gpt-3.5-turbo") -> str:
     """Return ChatGPT-formatted trip description."""
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
 
-    prompt = load_prompt().format(data=json.dumps(data, ensure_ascii=False), language=language)
+    short_data = extract_trip_info(data)
+    prompt = load_prompt().format(data=json.dumps(short_data, ensure_ascii=False), language=language)
     client = openai.OpenAI(api_key=api_key)
     response = client.chat.completions.create(
         model=model,


### PR DESCRIPTION
## Summary
- add helper functions to extract minimal trip/departure data
- use reduced trip data when formatting with ChatGPT

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e2023cff0832198703efce7ab4402