### PR TITLE
Handle stop verification and departure formatting

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -35,7 +35,22 @@ def main() -> None:
             print(json.dumps(q.__dict__, indent=2, ensure_ascii=False))
 
         if q.type == "trip" and q.from_location and q.to_location:
-            data = efa_api.trip_request(q.from_location, q.to_location, q.datetime)
+            from_sf = efa_api.stop_finder(q.from_location)
+            from_points = from_sf.get("stopFinder", {}).get("points", [])
+            to_sf = efa_api.stop_finder(q.to_location)
+            to_points = to_sf.get("stopFinder", {}).get("points", [])
+            if not from_points or not to_points:
+                print("Stop not found")
+                continue
+            from_point = from_points[0]
+            to_point = to_points[0]
+            data = efa_api.trip_request(
+                from_point.get("name", q.from_location),
+                to_point.get("name", q.to_location),
+                q.datetime,
+                origin_stateless=from_point.get("stateless"),
+                destination_stateless=to_point.get("stateless"),
+            )
             if args.llm_format:
                 try:
                     print(llm_formatter.format_trip(data, language=q.language or "de"))
@@ -44,8 +59,23 @@ def main() -> None:
             else:
                 print(data)
         elif q.type == "departure" and q.from_location:
-            data = efa_api.departure_monitor(q.from_location)
-            print(data)
+            sf_data = efa_api.stop_finder(q.from_location)
+            points = sf_data.get("stopFinder", {}).get("points", [])
+            if not points:
+                print("Stop not found")
+                continue
+            point = points[0]
+            data = efa_api.departure_monitor(
+                point.get("name", q.from_location),
+                stateless=point.get("stateless"),
+            )
+            if args.llm_format:
+                try:
+                    print(llm_formatter.format_departures(data, language=q.language or "de"))
+                except Exception as exc:
+                    print(f"Format error: {exc}")
+            else:
+                print(data)
         else:
             print("Couldn't understand query")
 

--- a/src/llm_formatter.py
+++ b/src/llm_formatter.py
@@ -3,7 +3,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 import openai
 
@@ -15,13 +15,124 @@ def load_prompt() -> str:
     return PROMPT_PATH.read_text(encoding="utf-8")
 
 
+def _extract_time(point: Dict[str, Any]) -> Dict[str, Optional[str]]:
+    """Return planned and real time strings from a point."""
+    if not isinstance(point, dict):
+        return {"time": None, "rtTime": None}
+    dt = point.get("dateTime", {})
+    time = None
+    rt_time = None
+    if isinstance(dt, dict):
+        hour = dt.get("time")
+        if hour:
+            time = hour
+        rt_hour = dt.get("rtTime")
+        if rt_hour:
+            rt_time = rt_hour
+    return {"time": time, "rtTime": rt_time}
+
+
+def extract_trip_info(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return minimal information about a trip."""
+    trip = data.get("trips", {}).get("trip")
+    if isinstance(trip, list):
+        trip = trip[0] if trip else {}
+    if not isinstance(trip, dict):
+        return {}
+    result: Dict[str, Any] = {
+        "duration": trip.get("duration"),
+        "interchange": trip.get("interchange"),
+        "legs": [],
+    }
+    legs: List[Dict[str, Any]] = trip.get("legs", [])
+    if isinstance(legs, dict):
+        legs = legs.get("leg", [])  # type: ignore[assignment]
+    for leg in legs:
+        points = leg.get("points", [])
+        if isinstance(points, dict):
+            points = points.get("point", [])  # type: ignore[assignment]
+        if len(points) < 2:
+            continue
+        start = points[0]
+        end = points[-1]
+        mode = leg.get("mode", {})
+        leg_info = {
+            "line": mode.get("name"),
+            "number": mode.get("number"),
+            "direction": mode.get("destination"),
+            "origin": start.get("name"),
+            "destination": end.get("name"),
+        }
+        leg_info.update(_extract_time(start))
+        arrival_times = _extract_time(end)
+        leg_info["arrival"] = arrival_times.get("time")
+        leg_info["rtArrival"] = arrival_times.get("rtTime")
+        result["legs"].append(leg_info)
+    return result
+
+
+def extract_departure_info(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return minimal information about upcoming departures."""
+    departures: List[Dict[str, Any]] = []
+    dep_list = data.get("departureList")
+    if isinstance(dep_list, dict):
+        dep_list = dep_list.get("departure", [])
+    if not isinstance(dep_list, list):
+        dep_list = []
+    for dep in dep_list:
+        line = dep.get("servingLine", {})
+        dt = dep.get("dateTime", {})
+        rt = dep.get("realDateTime", {})
+        time = None
+        rt_time = None
+        if dt:
+            hour = dt.get("hour")
+            minute = dt.get("minute")
+            if hour is not None and minute is not None:
+                time = f"{hour}:{minute.zfill(2)}" if isinstance(minute, str) else f"{hour}:{minute:02d}"
+        if rt:
+            hour = rt.get("hour")
+            minute = rt.get("minute")
+            if hour is not None and minute is not None:
+                rt_time = f"{hour}:{minute.zfill(2)}" if isinstance(minute, str) else f"{hour}:{minute:02d}"
+        departures.append(
+            {
+                "stop": dep.get("stopName"),
+                "line": line.get("name"),
+                "number": line.get("number"),
+                "direction": line.get("direction"),
+                "time": time,
+                "rtTime": rt_time,
+            }
+        )
+    return {"departures": departures}
+
+
 def format_trip(data: Dict[str, Any], language: str = "de", model: str = "gpt-3.5-turbo") -> str:
     """Return ChatGPT-formatted trip description."""
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
 
-    prompt = load_prompt().format(data=json.dumps(data, ensure_ascii=False), language=language)
+    short_data = extract_trip_info(data)
+    prompt = load_prompt().format(data=json.dumps(short_data, ensure_ascii=False), language=language)
+    client = openai.OpenAI(api_key=api_key)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "system", "content": prompt}],
+        max_tokens=200,
+    )
+    return response.choices[0].message.content.strip()
+
+
+def format_departures(data: Dict[str, Any], language: str = "de", model: str = "gpt-3.5-turbo") -> str:
+    """Return ChatGPT-formatted departure list."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set")
+
+    short_data = extract_departure_info(data)
+    prompt = load_prompt().format(data=json.dumps(short_data, ensure_ascii=False), language=language)
     client = openai.OpenAI(api_key=api_key)
     response = client.chat.completions.create(
         model=model,

--- a/src/llm_formatter.py
+++ b/src/llm_formatter.py
@@ -34,9 +34,15 @@ def _extract_time(point: Dict[str, Any]) -> Dict[str, Optional[str]]:
 
 def extract_trip_info(data: Dict[str, Any]) -> Dict[str, Any]:
     """Return minimal information about a trip."""
-    trip = data.get("trips", {}).get("trip")
-    if isinstance(trip, list):
-        trip = trip[0] if trip else {}
+    trips = data.get("trips")
+    if isinstance(trips, dict):
+        trips = trips.get("trip")
+    if isinstance(trips, list):
+        trip = trips[0] if trips else None
+    elif isinstance(trips, dict):
+        trip = trips
+    else:
+        trip = None
     if not isinstance(trip, dict):
         return {}
     result: Dict[str, Any] = {
@@ -44,9 +50,11 @@ def extract_trip_info(data: Dict[str, Any]) -> Dict[str, Any]:
         "interchange": trip.get("interchange"),
         "legs": [],
     }
-    legs: List[Dict[str, Any]] = trip.get("legs", [])
+    legs = trip.get("legs")
     if isinstance(legs, dict):
         legs = legs.get("leg", [])  # type: ignore[assignment]
+    if not isinstance(legs, list):
+        legs = []
     for leg in legs:
         points = leg.get("points", [])
         if isinstance(points, dict):

--- a/src/main.py
+++ b/src/main.py
@@ -62,9 +62,18 @@ def search(body: SearchRequest, format: str = Query("json")) -> Any:
         origin_stateless=from_stateless,
         destination_stateless=to_stateless,
     )
+    short_data = llm_formatter.extract_trip_info(data)
     try:
         text = llm_formatter.format_trip(data, language=q.language or "de")
-        return text if format == "text" else {"data": text}
+        if format == "text":
+            return text
+        return {
+            "input": body.text,
+            "from": from_point,
+            "to": to_point,
+            "llmData": short_data,
+            "data": text,
+        }
     except Exception as exc:  # pragma: no cover - no tests
         raise HTTPException(status_code=500, detail=str(exc))
 
@@ -80,7 +89,19 @@ def departures(body: DeparturesRequest, format: str = Query("json")) -> Any:
     verified = point.get("name", body.stop)
     stateless = point.get("stateless")
     data = efa_api.departure_monitor(verified, body.limit, stateless=stateless)
-    return data if format == "text" else {"data": data}
+    short_data = llm_formatter.extract_departure_info(data)
+    try:
+        text = llm_formatter.format_departures(data, language="de")
+        if format == "text":
+            return text
+        return {
+            "input": body.stop,
+            "stop": point,
+            "llmData": short_data,
+            "data": text,
+        }
+    except Exception as exc:  # pragma: no cover - no tests
+        raise HTTPException(status_code=500, detail=str(exc))
 
 
 @app.post("/stops")


### PR DESCRIPTION
## Summary
- verify stops with Stopfinder in console chat
- add support for LLM formatting of departures
- handle list structures in EFA responses
- return debug info from `/search` and `/departures`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e2023cff0832198703efce7ab4402