### PR TITLE
Improve debug output

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -44,6 +44,23 @@ def main() -> None:
                 continue
             from_point = from_points[0]
             to_point = to_points[0]
+            if args.debug:
+                debug_info = {
+                    "fromStateless": from_point.get("stateless"),
+                    "toStateless": to_point.get("stateless"),
+                }
+                params = efa_api.build_trip_params(
+                    from_point.get("name", q.from_location),
+                    to_point.get("name", q.to_location),
+                    q.datetime,
+                    origin_stateless=from_point.get("stateless"),
+                    destination_stateless=to_point.get("stateless"),
+                )
+                debug_info["request"] = {
+                    "url": f"{efa_api.BASE_URL}/XML_TRIP_REQUEST2",
+                    "params": params,
+                }
+                print(json.dumps(debug_info, indent=2, ensure_ascii=False))
             data = efa_api.trip_request(
                 from_point.get("name", q.from_location),
                 to_point.get("name", q.to_location),
@@ -65,6 +82,19 @@ def main() -> None:
                 print("Stop not found")
                 continue
             point = points[0]
+            if args.debug:
+                params = efa_api.build_departure_params(
+                    point.get("name", q.from_location),
+                    stateless=point.get("stateless"),
+                )
+                debug_info = {
+                    "stateless": point.get("stateless"),
+                    "request": {
+                        "url": f"{efa_api.BASE_URL}/XML_DM_REQUEST",
+                        "params": params,
+                    },
+                }
+                print(json.dumps(debug_info, indent=2, ensure_ascii=False))
             data = efa_api.departure_monitor(
                 point.get("name", q.from_location),
                 stateless=point.get("stateless"),

--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -7,15 +7,15 @@ import requests
 BASE_URL = os.getenv("EFA_BASE_URL", "https://efa.sta.bz.it/apb")
 
 
-def trip_request(
+def build_trip_params(
     origin: str,
     destination: str,
     datetime: Optional[str] = None,
     origin_stateless: Optional[str] = None,
     destination_stateless: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Request a trip from origin to destination."""
-    params = {"outputFormat": "JSON"}
+    """Return parameters for a trip request."""
+    params: Dict[str, Any] = {"outputFormat": "JSON"}
     if origin_stateless:
         params["name_origin"] = origin_stateless
         params["type_origin"] = "stop"
@@ -29,10 +29,49 @@ def trip_request(
     else:
         params["name_destination"] = destination
         params["type_destination"] = "any"
+
     if datetime:
         date, time = datetime.split("T")
         params["itdDate"] = date
         params["itdTime"] = time
+    return params
+
+
+def build_departure_params(
+    stop: str,
+    limit: int = 5,
+    stateless: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Return parameters for a departure monitor request."""
+    params: Dict[str, Any] = {
+        "mode": "direct",
+        "limit": limit,
+        "outputFormat": "JSON",
+    }
+    if stateless:
+        params["name_dm"] = stateless
+        params["type_dm"] = "stop"
+    else:
+        params["name_dm"] = stop
+        params["type_dm"] = "stop"
+    return params
+
+
+def trip_request(
+    origin: str,
+    destination: str,
+    datetime: Optional[str] = None,
+    origin_stateless: Optional[str] = None,
+    destination_stateless: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Request a trip from origin to destination."""
+    params = build_trip_params(
+        origin,
+        destination,
+        datetime,
+        origin_stateless=origin_stateless,
+        destination_stateless=destination_stateless,
+    )
     response = requests.get(f"{BASE_URL}/XML_TRIP_REQUEST2", params=params, timeout=10)
     response.raise_for_status()
     return response.json()
@@ -44,17 +83,7 @@ def departure_monitor(
     stateless: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Return upcoming departures for a stop."""
-    params = {
-        "mode": "direct",
-        "limit": limit,
-        "outputFormat": "JSON",
-    }
-    if stateless:
-        params["name_dm"] = stateless
-        params["type_dm"] = "stop"
-    else:
-        params["name_dm"] = stop
-        params["type_dm"] = "stop"
+    params = build_departure_params(stop, limit, stateless=stateless)
     response = requests.get(f"{BASE_URL}/XML_DM_REQUEST", params=params, timeout=10)
     response.raise_for_status()
     return response.json()


### PR DESCRIPTION
## Summary
- add helper functions to build request parameters for debugging purposes
- display EFA request details and stateless stop codes when using `chat.py --debug`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e36903de08321ab888566cbc6933f