### PR TITLE
Fix Telegram bot query parameters

### DIFF
--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -95,7 +95,7 @@ async def handle(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     if state == "search":
         context.user_data.pop("state", None)
-        reply = call_api("/search", {"text": text}, params={"format": "text", "chatgpt": "true"})
+        reply = call_api("/search", {"text": text}, params={"format": "text"})
         await send_reply(update, reply)
         return
     if state == "departures":
@@ -110,7 +110,7 @@ async def handle(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
 
     # fallback: try /search
-    reply = call_api("/search", {"text": text}, params={"format": "text", "chatgpt": "true"})
+    reply = call_api("/search", {"text": text}, params={"format": "text"})
     await send_reply(update, reply)
 
 


### PR DESCRIPTION
## Summary
- remove `chatgpt=true` parameter from Telegram bot requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e39b7454083219fe2aa1e044edb6a