### PR TITLE
Add helper functions for all config variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@ EFA_BASE_URL=https://efa.sta.bz.it/apb
 # API key for ChatGPT features
 OPENAI_API_KEY=
 
+# OpenAI model name for ChatGPT features
+OPENAI_MODEL=gpt-4
+
+# Parameter name for output length
+OPENAI_MAX_TOKENS_PARAM=max_tokens
+
 # Token for the Telegram bot
 TELEGRAM_TOKEN=
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,15 @@ The service can be configured via the following environment variables:
   ```
 - `OPENAI_API_KEY` – API key for ChatGPT.
 ```bash
-OPENAI_API_KEY=sk-... 
+OPENAI_API_KEY=sk-...
+```
+- `OPENAI_MODEL` – OpenAI model name used for LLM features
+```bash
+OPENAI_MODEL=gpt-4
+```
+- `OPENAI_MAX_TOKENS_PARAM` – parameter name for limiting output length
+```bash
+OPENAI_MAX_TOKENS_PARAM=max_tokens
 ```
 - `TELEGRAM_TOKEN` – required for the Telegram bot
   ```bash

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,55 @@
+"""Configuration helpers for suedtirolmobilAI."""
+
+import os
+
+
+def get_openai_model() -> str:
+    """Return the OpenAI model name.
+
+    The value is taken from the ``OPENAI_MODEL`` environment variable and
+    defaults to ``gpt-3.5-turbo``.
+    """
+    return os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+
+
+def get_openai_api_key() -> str:
+    """Return the OpenAI API key.
+
+    Raises ``RuntimeError`` if the variable is not set.
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set")
+    return api_key
+
+
+def get_openai_max_tokens_param() -> str:
+    """Return the parameter name for limiting completion length."""
+    return os.getenv("OPENAI_MAX_TOKENS_PARAM", "max_tokens")
+
+
+def get_efa_base_url() -> str:
+    """Return the Mentz EFA API base URL."""
+    return os.getenv("EFA_BASE_URL", "https://efa.sta.bz.it/apb")
+
+
+def get_api_url() -> str:
+    """Return the API base URL used by the Telegram bot."""
+    return os.getenv("API_URL", "http://localhost:8000")
+
+
+def get_telegram_token(*, required: bool = False) -> str:
+    """Return the Telegram bot token.
+
+    When ``required`` is ``True`` a ``RuntimeError`` is raised if the variable
+    is not set.
+    """
+    token = os.getenv("TELEGRAM_TOKEN")
+    if required and not token:
+        raise RuntimeError("TELEGRAM_TOKEN not set")
+    return token or ""
+
+
+def get_server_url() -> str:
+    """Return the public server URL."""
+    return os.getenv("SERVER_URL", "https://api.example.com")

--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -1,10 +1,11 @@
 """Simple wrapper for the Mentz EFA API."""
 
 from typing import Optional, Dict, Any
-import os
 import requests
 
-BASE_URL = os.getenv("EFA_BASE_URL", "https://efa.sta.bz.it/apb")
+from .config import get_efa_base_url
+
+BASE_URL = get_efa_base_url()
 
 
 def build_trip_params(

--- a/src/llm_formatter.py
+++ b/src/llm_formatter.py
@@ -1,11 +1,16 @@
 """Format EFA responses using OpenAI."""
 
 import json
-import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import openai
+
+from .config import (
+    get_openai_api_key,
+    get_openai_max_tokens_param,
+    get_openai_model,
+)
 
 PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "formatter_prompt.txt"
 
@@ -122,38 +127,52 @@ def extract_departure_info(data: Dict[str, Any]) -> Dict[str, Any]:
     return {"departures": departures}
 
 
-def format_trip(data: Dict[str, Any], language: str = "de", model: str = "gpt-3.5-turbo") -> str:
-    """Return ChatGPT-formatted trip description."""
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise RuntimeError("OPENAI_API_KEY not set")
+def format_trip(
+    data: Dict[str, Any], language: str = "de", model: Optional[str] = None
+) -> str:
+    """Return ChatGPT-formatted trip description.
+
+    The ``OPENAI_MODEL`` environment variable is used when ``model`` is not
+    provided.
+    """
+    if model is None:
+        model = get_openai_model()
+    api_key = get_openai_api_key()
 
     short_data = extract_trip_info(data)
     prompt = load_prompt().format(data=json.dumps(short_data, ensure_ascii=False), language=language)
 
     client = openai.OpenAI(api_key=api_key)
+    param = {get_openai_max_tokens_param(): 200}
     response = client.chat.completions.create(
         model=model,
         messages=[{"role": "system", "content": prompt}],
-        max_tokens=200,
+        **param,
     )
     return response.choices[0].message.content.strip()
 
 
-def format_departures(data: Dict[str, Any], language: str = "de", model: str = "gpt-3.5-turbo") -> str:
-    """Return ChatGPT-formatted departure list."""
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise RuntimeError("OPENAI_API_KEY not set")
+def format_departures(
+    data: Dict[str, Any], language: str = "de", model: Optional[str] = None
+) -> str:
+    """Return ChatGPT-formatted departure list.
+
+    The ``OPENAI_MODEL`` environment variable is used when ``model`` is not
+    provided.
+    """
+    if model is None:
+        model = get_openai_model()
+    api_key = get_openai_api_key()
 
     short_data = extract_departure_info(data)
     prompt = load_prompt().format(data=json.dumps(short_data, ensure_ascii=False), language=language)
 
 
     client = openai.OpenAI(api_key=api_key)
+    param = {get_openai_max_tokens_param(): 200}
     response = client.chat.completions.create(
         model=model,
         messages=[{"role": "system", "content": prompt}],
-        max_tokens=200,
+        **param,
     )
     return response.choices[0].message.content.strip()

--- a/src/llm_parser.py
+++ b/src/llm_parser.py
@@ -1,13 +1,17 @@
 """OpenAI-powered query parser."""
 
 import json
-import os
 from pathlib import Path
 from typing import Optional
 
 import openai
 
 from .parser import Query
+from .config import (
+    get_openai_api_key,
+    get_openai_max_tokens_param,
+    get_openai_model,
+)
 
 PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "parser_prompt.txt"
 
@@ -17,18 +21,23 @@ def load_prompt() -> str:
     return PROMPT_PATH.read_text(encoding="utf-8")
 
 
-def parse_llm(text: str, model: str = "gpt-3.5-turbo") -> Query:
-    """Parse a query via OpenAI API using the prompt template."""
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise RuntimeError("OPENAI_API_KEY not set")
+def parse_llm(text: str, model: Optional[str] = None) -> Query:
+    """Parse a query via OpenAI API using the prompt template.
+
+    The ``OPENAI_MODEL`` environment variable is used when ``model`` is not
+    provided.
+    """
+    if model is None:
+        model = get_openai_model()
+    api_key = get_openai_api_key()
 
     prompt = load_prompt().format(text=text)
     client = openai.OpenAI(api_key=api_key)
+    param = {get_openai_max_tokens_param(): 200}
     response = client.chat.completions.create(
         model=model,
         messages=[{"role": "system", "content": prompt}],
-        max_tokens=200,
+        **param,
     )
     content = response.choices[0].message.content.strip()
     data = json.loads(content)

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -4,7 +4,6 @@ import argparse
 import asyncio
 import json
 import logging
-import os
 import threading
 from typing import Dict, Any, List
 
@@ -14,8 +13,10 @@ from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandl
 
 MAX_MESSAGE_LENGTH = 4096
 
-API_URL = os.getenv("API_URL", "http://localhost:8000")
-TOKEN = os.getenv("TELEGRAM_TOKEN")
+from .config import get_api_url, get_telegram_token
+
+API_URL = get_api_url()
+TOKEN = get_telegram_token()
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- create dedicated helpers for OPENAI_API_KEY, API_URL, TELEGRAM_TOKEN, SERVER_URL and EFA_BASE_URL
- use the helpers throughout the codebase
- add new helper OPENAI_MAX_TOKENS_PARAM to support models that expect `max_completion_tokens`
- document the new variable in README and `.env.example`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e539dd5cc8321aa12b4474de0694d