### PR TITLE
Add transport filters and structured formatting

### DIFF
--- a/prompts/formatter_prompt.txt
+++ b/prompts/formatter_prompt.txt
@@ -1,5 +1,5 @@
 You are a helpful assistant that formats public transport connections.
-Use the provided data to create a short answer in {language}.
-Return only the text without further explanations.
+Use the provided data to create a short, structured answer in {language}.
+Return bullet points without additional explanations.
 Data:
 {data}

--- a/prompts/parser_prompt.txt
+++ b/prompts/parser_prompt.txt
@@ -4,7 +4,8 @@ Fields:
 - from: starting location or null
 - to: destination location or null
 - datetime: ISO format "YYYY-MM-DDTHH:MM" or null
-- transport_mode: "Bus", "Zug", "Seilbahn" or null
-- long_distance: true or false
+- include: list of desired transport modes or empty list
+- exclude: list of transport modes to skip or empty list
+- long_distance: true to allow long distance trains, false to exclude them
 - language: "de", "it", or "en"
 User text: {text}

--- a/src/chat.py
+++ b/src/chat.py
@@ -58,6 +58,9 @@ def main() -> None:
                     q.datetime,
                     origin_stateless=from_point.get("stateless"),
                     destination_stateless=to_point.get("stateless"),
+                    include=q.include,
+                    exclude=q.exclude,
+                    long_distance=q.long_distance,
                     language=q.language or "de",
                 )
                 debug_info["request"] = {
@@ -71,6 +74,9 @@ def main() -> None:
                 q.datetime,
                 origin_stateless=from_point.get("stateless"),
                 destination_stateless=to_point.get("stateless"),
+                include=q.include,
+                exclude=q.exclude,
+                long_distance=q.long_distance,
                 language=q.language or "de",
             )
             if args.llm_format:

--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -14,6 +14,9 @@ def build_trip_params(
     origin_stateless: Optional[str] = None,
     destination_stateless: Optional[str] = None,
     *,
+    include: Optional[list] = None,
+    exclude: Optional[list] = None,
+    long_distance: Optional[bool] = None,
     language: str = "de",
 ) -> Dict[str, Any]:
     """Return parameters for a trip request."""
@@ -36,6 +39,15 @@ def build_trip_params(
         date, time = datetime.split("T")
         params["itdDate"] = date
         params["itdTime"] = time
+    if include:
+        params["includedMeans"] = ",".join(include)
+    if exclude:
+        params["excludedMeans"] = ",".join(exclude)
+    if long_distance is False:
+        params.setdefault("excludedMeans", "")
+        if params["excludedMeans"]:
+            params["excludedMeans"] += ","
+        params["excludedMeans"] += "Fernverkehr"
     return params
 
 
@@ -69,6 +81,9 @@ def trip_request(
     origin_stateless: Optional[str] = None,
     destination_stateless: Optional[str] = None,
     *,
+    include: Optional[list] = None,
+    exclude: Optional[list] = None,
+    long_distance: Optional[bool] = None,
     language: str = "de",
 ) -> Dict[str, Any]:
     """Request a trip from origin to destination."""
@@ -78,6 +93,9 @@ def trip_request(
         datetime,
         origin_stateless=origin_stateless,
         destination_stateless=destination_stateless,
+        include=include,
+        exclude=exclude,
+        long_distance=long_distance,
         language=language,
     )
     response = requests.get(f"{BASE_URL}/XML_TRIP_REQUEST2", params=params, timeout=10)

--- a/src/llm_parser.py
+++ b/src/llm_parser.py
@@ -46,4 +46,7 @@ def parse_llm(text: str, model: Optional[str] = None) -> Query:
         datetime=data.get("datetime"),
         line=None,
         language=data.get("language"),
+        include=data.get("include"),
+        exclude=data.get("exclude"),
+        long_distance=data.get("long_distance"),
     )

--- a/src/main.py
+++ b/src/main.py
@@ -67,6 +67,9 @@ def search(body: SearchRequest, format: str = Query("json")) -> Any:
         q.datetime,
         origin_stateless=from_stateless,
         destination_stateless=to_stateless,
+        include=q.include,
+        exclude=q.exclude,
+        long_distance=q.long_distance,
         language=q.language or "de",
     )
     short_data = llm_formatter.extract_trip_info(data)

--- a/src/parser.py
+++ b/src/parser.py
@@ -2,7 +2,7 @@
 
 import re
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, List
 
 
 @dataclass
@@ -15,6 +15,9 @@ class Query:
     datetime: Optional[str] = None
     line: Optional[str] = None
     language: Optional[str] = None
+    include: Optional[List[str]] = None
+    exclude: Optional[List[str]] = None
+    long_distance: Optional[bool] = None
 
 
 TRIP_RE = re.compile(
@@ -22,11 +25,28 @@ TRIP_RE = re.compile(
     re.I,
 )
 DEPT_RE = re.compile(r"abfahrten? (?P<stop>\w+)", re.I)
+INCLUDE_RE = re.compile(r"mit (?P<modes>bus(?: und seilbahn)?)", re.I)
+EXCLUDE_RE = re.compile(r"ohne (?P<modes>zug|fernverkehr)", re.I)
 
 
 
 def parse(text: str) -> Query:
     """Parse a German language query."""
+    include_modes = []
+    exclude_modes = []
+    if m := INCLUDE_RE.search(text):
+        modes = m.group("modes").lower()
+        if "bus" in modes:
+            include_modes.append("Bus")
+        if "seilbahn" in modes:
+            include_modes.append("Seilbahn")
+    if m := EXCLUDE_RE.search(text):
+        mode = m.group("modes").lower()
+        if "zug" in mode:
+            exclude_modes.append("Zug")
+        if "fernverkehr" in mode:
+            exclude_modes.append("Fernverkehr")
+
     match = TRIP_RE.search(text)
     if match:
         dt = match.group("time")
@@ -39,10 +59,26 @@ def parse(text: str) -> Query:
             match.group("to"),
             iso,
             language="de",
+            include=include_modes or None,
+            exclude=exclude_modes or None,
+            long_distance=None if "Fernverkehr" not in exclude_modes else False,
         )
 
     match = DEPT_RE.search(text)
     if match:
-        return Query("departure", from_location=match.group("stop"), language="de")
+        return Query(
+            "departure",
+            from_location=match.group("stop"),
+            language="de",
+            include=include_modes or None,
+            exclude=exclude_modes or None,
+            long_distance=None if "Fernverkehr" not in exclude_modes else False,
+        )
 
-    return Query("unknown", language="de")
+    return Query(
+        "unknown",
+        language="de",
+        include=include_modes or None,
+        exclude=exclude_modes or None,
+        long_distance=None if "Fernverkehr" not in exclude_modes else False,
+    )


### PR DESCRIPTION
## Summary
- support transport mode filters when parsing text
- include filter fields in LLM parser
- pass filters to trip requests
- tweak prompts for parser and formatter
- output bullet-point format in ChatGPT answers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e5b617cf88321af2b51a23b92556d