### PR TITLE
Fix Italian responses

### DIFF
--- a/prompts/formatter_prompt.txt
+++ b/prompts/formatter_prompt.txt
@@ -1,3 +1,4 @@
 Please help me present public-transport connections in a clear and friendly way.
-Using the data below, write a concise, flowing text, well-structured in following language: "{language}"
+Using the data below, write a concise, flowing text in the "{language}" language.
+Respond only in that language.
 Data: {data}


### PR DESCRIPTION
## Summary
- improve Italian handling by refining prompt text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6d5e66508321b3dff3af5bdcaf24