### PR TITLE
Improve Telegram bot debug info

### DIFF
--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -2,7 +2,10 @@
 
 from typing import Optional, Dict, Any
 import os
+import logging
 import requests
+
+logger = logging.getLogger(__name__)
 
 BASE_URL = os.getenv("EFA_BASE_URL", "https://efa.sta.bz.it/apb")
 
@@ -98,7 +101,9 @@ def trip_request(
         long_distance=long_distance,
         language=language,
     )
-    response = requests.get(f"{BASE_URL}/XML_TRIP_REQUEST2", params=params, timeout=10)
+    url = f"{BASE_URL}/XML_TRIP_REQUEST2"
+    logger.debug("EFA request %s %s", url, params)
+    response = requests.get(url, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -114,7 +119,9 @@ def departure_monitor(
     params = build_departure_params(
         stop, limit, stateless=stateless, language=language
     )
-    response = requests.get(f"{BASE_URL}/XML_DM_REQUEST", params=params, timeout=10)
+    url = f"{BASE_URL}/XML_DM_REQUEST"
+    logger.debug("EFA request %s %s", url, params)
+    response = requests.get(url, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -127,7 +134,9 @@ def stop_finder(query: str, *, language: str = "de") -> Dict[str, Any]:
         "outputFormat": "JSON",
         "language": language,
     }
-    response = requests.get(f"{BASE_URL}/XML_STOPFINDER_REQUEST", params=params, timeout=10)
+    url = f"{BASE_URL}/XML_STOPFINDER_REQUEST"
+    logger.debug("EFA request %s %s", url, params)
+    response = requests.get(url, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
 

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -8,7 +8,7 @@ import os
 import threading
 from typing import Dict, Any, List
 
-from . import parser, efa_api
+from . import parser, efa_api, llm_parser
 
 import requests
 from telegram import Update, KeyboardButton, ReplyKeyboardMarkup
@@ -69,9 +69,14 @@ async def send_reply(update: Update, text: str) -> None:
 def gather_debug_entries(text: str, state: str = None) -> List[Dict[str, Any]]:
     """Return debug information for a query."""
     if state == "departures":
-        query = parser.Query("departure", from_location=text, language="en")
+        query = parser.Query("departure", from_location=text, language="de")
     else:
         query = parser.parse(text)
+        if query.type != "trip" or not query.from_location or not query.to_location:
+            try:
+                query = llm_parser.parse_llm(text)
+            except Exception as exc:  # pragma: no cover - network
+                logger.error("LLM parse failed: %s", exc)
     entries: List[Dict[str, Any]] = [query.__dict__]
     if query.type == "trip" and query.from_location and query.to_location:
         from_sf = efa_api.stop_finder(query.from_location, language=query.language or "de")
@@ -221,9 +226,12 @@ def main() -> None:
     if not args.token:
         parser.error("Telegram token not provided")
     if args.debug:
-        logging.getLogger().setLevel(logging.DEBUG)
         global DEBUG
         DEBUG = True
+        logger.setLevel(logging.DEBUG)
+        logging.getLogger("httpx").setLevel(logging.INFO)
+        logging.getLogger("httpcore").setLevel(logging.INFO)
+        logging.getLogger("telegram.ext").setLevel(logging.INFO)
         logger.debug("Debug mode active")
         logger.debug("Args: %s", args)
     run_bot(args.token, args.start_server)


### PR DESCRIPTION
## Summary
- show LLM-parsed parameters in telegram bot debug output
- use German by default for debug departure queries
- hide httpx debug logs when `--debug` flag is used
- log EFA requests in `efa_api`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e700f87a08321ba63f339c5ff82d4