### PR TITLE
Suppress httpx info logs

### DIFF
--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -229,8 +229,8 @@ def main() -> None:
         global DEBUG
         DEBUG = True
         logger.setLevel(logging.DEBUG)
-        logging.getLogger("httpx").setLevel(logging.INFO)
-        logging.getLogger("httpcore").setLevel(logging.INFO)
+        logging.getLogger("httpx").setLevel(logging.WARNING)
+        logging.getLogger("httpcore").setLevel(logging.WARNING)
         logging.getLogger("telegram.ext").setLevel(logging.INFO)
         logger.debug("Debug mode active")
         logger.debug("Args: %s", args)


### PR DESCRIPTION
## Summary
- don't print HTTP request logs from httpx in Telegram bot

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e729559888321a4eabd040e2a2ad8