### PR TITLE
Shorter LLM responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ OPENAI_API_KEY=
 
 # OpenAI model name for ChatGPT features
 OPENAI_MODEL=o4-mini
+# Maximum tokens for ChatGPT replies
+OPENAI_MAX_TOKENS=120
 
 # Token for the Telegram bot
 TELEGRAM_TOKEN=

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ OPENAI_API_KEY=sk-...
 ```bash
 OPENAI_MODEL=gpt-4
 ```
+`OPENAI_MAX_TOKENS` – maximum tokens for ChatGPT replies (default 100)
+```bash
+OPENAI_MAX_TOKENS=120
+```
 - `TELEGRAM_TOKEN` – required for the Telegram bot
   ```bash
   TELEGRAM_TOKEN=your_token

--- a/src/config.py
+++ b/src/config.py
@@ -10,3 +10,15 @@ def get_openai_model() -> str:
     defaults to ``gpt-3.5-turbo``.
     """
     return os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+
+
+def get_openai_max_tokens(default: int = 100) -> int:
+    """Return the maximum number of tokens for OpenAI replies.
+
+    The value is taken from the ``OPENAI_MAX_TOKENS`` environment variable
+    and falls back to ``default`` when not set or invalid.
+    """
+    value = os.getenv("OPENAI_MAX_TOKENS")
+    if value and value.isdigit():
+        return int(value)
+    return default

--- a/src/llm_formatter.py
+++ b/src/llm_formatter.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 
 import openai
 
-from .config import get_openai_model
+from .config import get_openai_model, get_openai_max_tokens
 
 PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "formatter_prompt.txt"
 
@@ -125,7 +125,10 @@ def extract_departure_info(data: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def format_trip(
-    data: Dict[str, Any], language: str = "de", model: Optional[str] = None
+    data: Dict[str, Any],
+    language: str = "de",
+    model: Optional[str] = None,
+    max_tokens: Optional[int] = None,
 ) -> str:
     """Return ChatGPT-formatted trip description.
 
@@ -134,6 +137,8 @@ def format_trip(
     """
     if model is None:
         model = get_openai_model()
+    if max_tokens is None:
+        max_tokens = get_openai_max_tokens()
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
@@ -145,13 +150,16 @@ def format_trip(
     response = client.chat.completions.create(
         model=model,
         messages=[{"role": "system", "content": prompt}],
-        max_tokens=200,
+        max_tokens=max_tokens,
     )
     return response.choices[0].message.content.strip()
 
 
 def format_departures(
-    data: Dict[str, Any], language: str = "de", model: Optional[str] = None
+    data: Dict[str, Any],
+    language: str = "de",
+    model: Optional[str] = None,
+    max_tokens: Optional[int] = None,
 ) -> str:
     """Return ChatGPT-formatted departure list.
 
@@ -160,6 +168,8 @@ def format_departures(
     """
     if model is None:
         model = get_openai_model()
+    if max_tokens is None:
+        max_tokens = get_openai_max_tokens()
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
@@ -172,6 +182,6 @@ def format_departures(
     response = client.chat.completions.create(
         model=model,
         messages=[{"role": "system", "content": prompt}],
-        max_tokens=200,
+        max_tokens=max_tokens,
     )
     return response.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- let responses be shorter by default using new `OPENAI_MAX_TOKENS` setting
- document the new variable in README
- add `OPENAI_MAX_TOKENS` to `.env.example`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e7392932c832183a89185b1757238