### PR TITLE
Fix date for 'heute' queries

### DIFF
--- a/src/llm_parser.py
+++ b/src/llm_parser.py
@@ -45,11 +45,16 @@ def parse_llm(text: str, model: Optional[str] = None) -> Query:
         try:
             dt = datetime.fromisoformat(dt_value)
             now = datetime.now()
-            if dt.year != now.year:
+            if "heute" in text.lower():
+                dt = dt.replace(year=now.year, month=now.month, day=now.day)
+            elif dt.year != now.year:
                 dt = dt.replace(year=now.year)
-                data["datetime"] = dt.strftime("%Y-%m-%dT%H:%M")
+            data["datetime"] = dt.strftime("%Y-%m-%dT%H:%M")
         except ValueError:
             pass
+    elif "heute" in text.lower():
+        now = datetime.now()
+        data["datetime"] = now.strftime("%Y-%m-%dT%H:%M")
     return Query(
         type=data.get("type", "unknown"),
         from_location=data.get("from"),

--- a/src/parser.py
+++ b/src/parser.py
@@ -72,7 +72,11 @@ def parse(text: str) -> Query:
         dt = match.group("time")
         iso = None
         if dt:
-            iso = f"2025-01-01T{dt}"
+            if "heute" in text.lower():
+                today = datetime.now().strftime("%Y-%m-%d")
+                iso = f"{today}T{dt}"
+            else:
+                iso = f"2025-01-01T{dt}"
         return Query(
             "trip",
             match.group("from"),


### PR DESCRIPTION
## Summary
- parse `heute` in rule-based parser
- adjust LLM parser to overwrite dates when `heute` is mentioned

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e7f61a0d48321bac558d22a68e3c0