### PR TITLE
Support uvicorn debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Start the server with:
 ```bash
 uvicorn src.main:app --host 0.0.0.0 --reload
 ```
+Append `--debug` for verbose logging.
 Alternatively run `python -m src.main` for the default settings.
 
 ## Configuration

--- a/install.sh
+++ b/install.sh
@@ -81,3 +81,4 @@ source venv/bin/activate
 echo "\nInstallation complete."
 echo "Activate the environment with source venv/bin/activate"
 echo "Run the server using: uvicorn src.main:app --host 0.0.0.0 --reload"
+echo "Append --debug for verbose logging."

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi
 requests
 spacy<3.8
 pydantic
-uvicorn
+uvicorn<0.19
 pytest
 httpx<0.25
 langdetect


### PR DESCRIPTION
## Summary
- pin `uvicorn` below 0.19 to restore `--debug` flag
- document `--debug` option in README
- mention optional debug flag in install instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f7a396d2483218647608c3b3b990a