### PR TITLE
Improve datetime handling in LLM parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Both templates contain placeholders that are replaced automatically:
 
 Edit the files to change the wording or add additional instructions.
 
+`parser_prompt.txt` now returns the date expression literally, for example
+"heute", "tomorrow" or "next sunday". The parser translates these phrases into
+a proper ISO timestamp when processing the response.
+
 ## Console chat
 Start a minimal interactive chat loop. Combine `--llm-parser` and `--llm-format` to use OpenAI for parsing and formatting.
 Add `--debug` to print the parsed query JSON.

--- a/prompts/parser_prompt.txt
+++ b/prompts/parser_prompt.txt
@@ -3,7 +3,7 @@ Fields:
 - type: "trip", "departure", or "stop"
 - from: starting location or null
 - to: destination location or null
-- datetime: ISO format "YYYY-MM-DDTHH:MM" or null
+- datetime: the literal date expression such as "heute", "tomorrow", a date and time, "next sunday", "am Dienstag", "martedì prossimo" or null
 - datetime_mode: "dep" for departure or "arr" for arrival time
 - bus: true or false
 - zug: true or false

--- a/src/llm_parser.py
+++ b/src/llm_parser.py
@@ -3,6 +3,7 @@
 import json
 import os
 from datetime import datetime
+import re
 from pathlib import Path
 from typing import Optional
 
@@ -17,6 +18,28 @@ PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "parser_promp
 def load_prompt() -> str:
     """Return parser prompt template."""
     return PROMPT_PATH.read_text(encoding="utf-8")
+
+
+def _normalize_datetime(dt_value: Optional[str], text: str) -> str:
+    """Return ISO timestamp from a datetime field or fallback text."""
+    now = datetime.now()
+    if dt_value:
+        time_match = re.search(r"\d{1,2}:\d{2}", dt_value)
+        iso = relative_iso(dt_value, time_match.group(0) if time_match else None)
+        if iso:
+            return iso
+        try:
+            dt = datetime.fromisoformat(dt_value)
+        except ValueError:
+            pass
+        else:
+            if dt.year != now.year:
+                dt = dt.replace(year=now.year)
+            return dt.strftime("%Y-%m-%dT%H:%M")
+    iso = relative_iso(text)
+    if iso:
+        return iso
+    return now.strftime("%Y-%m-%dT%H:%M")
 
 
 def parse_llm(text: str, model: Optional[str] = None) -> Query:
@@ -40,22 +63,7 @@ def parse_llm(text: str, model: Optional[str] = None) -> Query:
     )
     content = response.choices[0].message.content.strip()
     data = json.loads(content)
-    dt_value = data.get("datetime")
-    if dt_value:
-        try:
-            dt = datetime.fromisoformat(dt_value)
-            now = datetime.now()
-            if dt.year != now.year:
-                dt = dt.replace(year=now.year)
-            data["datetime"] = dt.strftime("%Y-%m-%dT%H:%M")
-        except ValueError:
-            pass
-    else:
-        iso = relative_iso(text)
-        if iso:
-            data["datetime"] = iso
-        else:
-            data["datetime"] = datetime.now().strftime("%Y-%m-%dT%H:%M")
+    data["datetime"] = _normalize_datetime(data.get("datetime"), text)
     return Query(
         type=data.get("type", "unknown"),
         from_location=data.get("from"),

--- a/tests/test_normalize_datetime.py
+++ b/tests/test_normalize_datetime.py
@@ -1,0 +1,24 @@
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from datetime import datetime, timedelta
+
+from src.llm_parser import _normalize_datetime
+
+
+def test_normalize_today():
+    iso = _normalize_datetime("heute", "")
+    assert iso.startswith(datetime.now().strftime("%Y-%m-%d"))
+
+
+def test_normalize_morgen_time():
+    iso = _normalize_datetime("morgen um 09:15", "")
+    tomorrow = datetime.now() + timedelta(days=1)
+    expected = tomorrow.strftime("%Y-%m-%dT09:15")
+    assert iso == expected
+
+
+def test_normalize_iso():
+    iso = _normalize_datetime("2025-03-05T10:30", "")
+    year = datetime.now().year
+    expected = datetime(year, 3, 5, 10, 30).strftime("%Y-%m-%dT%H:%M")
+    assert iso == expected


### PR DESCRIPTION
## Summary
- update parser prompt to output relative date phrases
- handle relative datetime expressions in `llm_parser`
- document new behaviour in README
- add unit tests for `_normalize_datetime`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f844170c083218a810e754053f212