### PR TITLE
Add query logging to file

### DIFF
--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -5,6 +5,7 @@ import os
 import logging
 import datetime as dt
 import requests
+from . import request_logger
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +125,7 @@ def trip_request(
     )
     url = f"{BASE_URL}/XML_TRIP_REQUEST2"
     logger.debug("EFA request %s %s", url, params)
+    request_logger.log_entry({"url": url, "params": params})
     response = requests.get(url, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
@@ -142,6 +144,7 @@ def departure_monitor(
     )
     url = f"{BASE_URL}/XML_DM_REQUEST"
     logger.debug("EFA request %s %s", url, params)
+    request_logger.log_entry({"url": url, "params": params})
     response = requests.get(url, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
@@ -157,6 +160,7 @@ def stop_finder(query: str, *, language: str = "de") -> Dict[str, Any]:
     }
     url = f"{BASE_URL}/XML_STOPFINDER_REQUEST"
     logger.debug("EFA request %s %s", url, params)
+    request_logger.log_entry({"url": url, "params": params})
     response = requests.get(url, params=params, timeout=10)
     response.raise_for_status()
     return response.json()

--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 from fastapi import FastAPI, HTTPException, Query
 from pydantic import BaseModel
 
-from . import efa_api, parser, llm_parser, llm_formatter
+from . import efa_api, parser, llm_parser, llm_formatter, request_logger
 
 app = FastAPI()
 
@@ -57,6 +57,17 @@ def search(body: SearchRequest, format: str = Query("json")) -> Any:
             raise HTTPException(status_code=404, detail="stop not found")
         verified = point.get("name", q.from_location)
         stateless = point.get("stateless")
+        params = efa_api.build_departure_params(
+            verified, 10, stateless=stateless, language=q.language or "de"
+        )
+        request_logger.log_entry(
+            {
+                "input": body.text,
+                "stop": point,
+                "url": f"{efa_api.BASE_URL}/XML_DM_REQUEST",
+                "params": params,
+            }
+        )
         data = efa_api.departure_monitor(
             verified, 10, stateless=stateless, language=q.language or "de"
         )
@@ -96,6 +107,30 @@ def search(body: SearchRequest, format: str = Query("json")) -> Any:
     to_stateless = to_point.get("stateless")
     to_type = to_point.get("anyType")
 
+    params = efa_api.build_trip_params(
+        q.from_location,
+        q.to_location,
+        q.datetime,
+        origin_stateless=from_stateless,
+        destination_stateless=to_stateless,
+        origin_type=from_type,
+        destination_type=to_type,
+        bus=q.bus,
+        zug=q.zug,
+        seilbahn=q.seilbahn,
+        long_distance=q.long_distance,
+        datetime_mode=q.datetime_mode,
+        language=q.language or "de",
+    )
+    request_logger.log_entry(
+        {
+            "input": body.text,
+            "from": from_point,
+            "to": to_point,
+            "url": f"{efa_api.BASE_URL}/XML_TRIP_REQUEST2",
+            "params": params,
+        }
+    )
     data: Dict[str, Any] = efa_api.trip_request(
         q.from_location,
         q.to_location,
@@ -139,6 +174,17 @@ def departures(body: DeparturesRequest, format: str = Query("json")) -> Any:
         raise HTTPException(status_code=404, detail="stop not found")
     verified = point.get("name", body.stop)
     stateless = point.get("stateless")
+    params = efa_api.build_departure_params(
+        verified, body.limit, stateless=stateless, language=body.language
+    )
+    request_logger.log_entry(
+        {
+            "input": body.stop,
+            "stop": point,
+            "url": f"{efa_api.BASE_URL}/XML_DM_REQUEST",
+            "params": params,
+        }
+    )
     data = efa_api.departure_monitor(
         verified, body.limit, stateless=stateless, language=body.language
     )
@@ -160,6 +206,19 @@ def departures(body: DeparturesRequest, format: str = Query("json")) -> Any:
 @app.post("/stops")
 def stops(body: StopsRequest, format: str = Query("json")) -> Any:
     """Return stop name suggestions."""
+    params = {
+        "name_sf": body.query,
+        "odvSugMacro": "true",
+        "outputFormat": "JSON",
+        "language": body.language,
+    }
+    request_logger.log_entry(
+        {
+            "input": body.query,
+            "url": f"{efa_api.BASE_URL}/XML_STOPFINDER_REQUEST",
+            "params": params,
+        }
+    )
     data = efa_api.stop_finder(body.query, language=body.language)
     return data if format == "text" else {"data": data}
 

--- a/src/request_logger.py
+++ b/src/request_logger.py
@@ -1,0 +1,22 @@
+"""Simple JSON line logger for EFA requests."""
+
+import json
+import os
+import datetime as dt
+import logging
+from typing import Any, Dict
+
+LOG_PATH = os.getenv("REQUEST_LOG_FILE", "requests.log")
+logger = logging.getLogger(__name__)
+
+
+def log_entry(entry: Dict[str, Any]) -> None:
+    """Append a log entry as JSON line."""
+    entry = dict(entry)
+    entry.setdefault("timestamp", dt.datetime.utcnow().isoformat())
+    try:
+        with open(LOG_PATH, "a", encoding="utf-8") as f:
+            json.dump(entry, f, ensure_ascii=False)
+            f.write("\n")
+    except Exception:  # pragma: no cover - file system issues
+        logger.exception("Failed to write log entry")


### PR DESCRIPTION
## Summary
- implement `request_logger` for JSON line logging
- log EFA requests in `efa_api`
- record query details and parameters in API endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f9eac096483218e98e50287fd243c