### PR TITLE
Add systemd service templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ defaults to the value of the `API_URL` environment variable or
 When selecting a command from the bot's keyboard without additional text,
 the bot will ask for the required input before sending the request.
 
+## Autostart unter Linux
+Weitere Hinweise zur Einrichtung eines systemd-Dienstes befinden sich in
+[docs/autostart.md](docs/autostart.md). Als Vorlage können die Dateien im
+[systemd/](systemd/) Verzeichnis dienen. Nach dem Anlegen kann der Dienst mit
+`systemctl start`, `stop` und `restart` gesteuert werden.
+
 ## Testing
 ```bash
 pytest

--- a/docs/autostart.md
+++ b/docs/autostart.md
@@ -1,0 +1,85 @@
+# Autostart unter Linux
+
+Um den Server oder den Telegram-Chatbot automatisch zu starten, kann ein `systemd`-Dienst verwendet werden. Nach dem Anlegen des Dienstes kann er mit `start`, `stop` und `restart` gesteuert werden.
+
+## Vorbereitung
+
+1. Repository klonen und Abhängigkeiten installieren:
+   ```bash
+   git clone https://example.com/suedtirolmobilAI.git
+   cd suedtirolmobilAI
+   ./install.sh
+   ```
+2. Falls gewünscht, Umgebungsvariablen in einer `.env`-Datei im Projektverzeichnis hinterlegen. Diese Datei wird von der Anwendung automatisch geladen.
+
+Die Beispieldateien `systemd/suedtirolmobil.service` und
+`systemd/suedtirolmobil-bot.service` in diesem Repository können als Vorlage
+verwendet und nach `/etc/systemd/system/` kopiert werden.
+
+## systemd-Service für die API
+
+Erstelle die Datei `/etc/systemd/system/suedtirolmobil.service` mit folgendem Inhalt (Pfad gegebenenfalls anpassen):
+
+```ini
+[Unit]
+Description=suedtirolmobilAI API
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/path/zum/repo/suedtirolmobilAI
+ExecStart=/path/zum/repo/suedtirolmobilAI/venv/bin/uvicorn src.main:app --host 0.0.0.0
+EnvironmentFile=/path/zum/repo/suedtirolmobilAI/.env
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Anschließend den Dienst laden und aktivieren:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable suedtirolmobil.service
+sudo systemctl start suedtirolmobil.service
+```
+
+## systemd-Service für den Telegram-Bot
+
+Soll auch der Telegram-Bot automatisch starten, kann ein zweiter Dienst angelegt werden. Beispiel `/etc/systemd/system/suedtirolmobil-bot.service`:
+
+```ini
+[Unit]
+Description=suedtirolmobilAI Telegram Bot
+After=network.target suedtirolmobil.service
+
+[Service]
+Type=simple
+WorkingDirectory=/path/zum/repo/suedtirolmobilAI
+ExecStart=/path/zum/repo/suedtirolmobilAI/venv/bin/python -m src.telegram_bot --api-url http://localhost:8000
+EnvironmentFile=/path/zum/repo/suedtirolmobilAI/.env
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Dienst ebenfalls laden und aktivieren:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable suedtirolmobil-bot.service
+sudo systemctl start suedtirolmobil-bot.service
+```
+
+## Steuerung des Dienstes
+
+Die Dienste lassen sich jederzeit mit folgenden Befehlen steuern:
+
+```bash
+sudo systemctl start suedtirolmobil.service       # Startet die API
+sudo systemctl stop suedtirolmobil.service        # Stoppt die API
+sudo systemctl restart suedtirolmobil.service     # Startet die API neu
+```
+
+Für den Telegram-Bot entsprechend `suedtirolmobil-bot.service` verwenden.

--- a/systemd/suedtirolmobil-bot.service
+++ b/systemd/suedtirolmobil-bot.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=suedtirolmobilAI Telegram Bot
+After=network.target suedtirolmobil.service
+
+[Service]
+Type=simple
+# adjust this path to the repository location
+WorkingDirectory=/path/to/suedtirolmobilAI
+ExecStart=/path/to/suedtirolmobilAI/venv/bin/python -m src.telegram_bot --api-url http://localhost:8000
+EnvironmentFile=/path/to/suedtirolmobilAI/.env
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/suedtirolmobil.service
+++ b/systemd/suedtirolmobil.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=suedtirolmobilAI API
+After=network.target
+
+[Service]
+Type=simple
+# adjust this path to the repository location
+WorkingDirectory=/path/to/suedtirolmobilAI
+ExecStart=/path/to/suedtirolmobilAI/venv/bin/uvicorn src.main:app --host 0.0.0.0
+EnvironmentFile=/path/to/suedtirolmobilAI/.env
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- provide example systemd units in `systemd/`
- mention service templates in autostart docs and README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fb9505c6883219af44a8ce9f64462