### PR TITLE
Add systemd detection to install_services.sh

### DIFF
--- a/install_services.sh
+++ b/install_services.sh
@@ -4,6 +4,11 @@ set -e
 # Copy service templates to /etc/systemd/system and reload systemd.
 # Paths inside the unit files may need adjustment.
 
+if ! command -v systemctl >/dev/null || ! pidof systemd >/dev/null; then
+    echo "Error: systemd is not running. This script requires a system with systemd." >&2
+    exit 1
+fi
+
 SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 sudo cp "$SRC_DIR/systemd/suedtirolmobil.service" /etc/systemd/system/


### PR DESCRIPTION
## Summary
- prevent `install_services.sh` from running if systemd is not active

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fc680c93c8321928130d2d0070ae8