### PR TITLE
Log full request URLs in log entries

### DIFF
--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -125,7 +125,8 @@ def trip_request(
     )
     url = f"{BASE_URL}/XML_TRIP_REQUEST2"
     logger.debug("EFA request %s %s", url, params)
-    request_logger.log_entry({"url": url, "params": params})
+    full_url = requests.Request("GET", url, params=params).prepare().url
+    request_logger.log_entry({"url": full_url})
     response = requests.get(url, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
@@ -144,7 +145,8 @@ def departure_monitor(
     )
     url = f"{BASE_URL}/XML_DM_REQUEST"
     logger.debug("EFA request %s %s", url, params)
-    request_logger.log_entry({"url": url, "params": params})
+    full_url = requests.Request("GET", url, params=params).prepare().url
+    request_logger.log_entry({"url": full_url})
     response = requests.get(url, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
@@ -160,7 +162,8 @@ def stop_finder(query: str, *, language: str = "de") -> Dict[str, Any]:
     }
     url = f"{BASE_URL}/XML_STOPFINDER_REQUEST"
     logger.debug("EFA request %s %s", url, params)
-    request_logger.log_entry({"url": url, "params": params})
+    full_url = requests.Request("GET", url, params=params).prepare().url
+    request_logger.log_entry({"url": full_url})
     response = requests.get(url, params=params, timeout=10)
     response.raise_for_status()
     return response.json()

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 from fastapi import FastAPI, HTTPException, Query
 from pydantic import BaseModel
+import requests
 
 from . import efa_api, parser, llm_parser, llm_formatter, request_logger
 
@@ -60,12 +61,16 @@ def search(body: SearchRequest, format: str = Query("json")) -> Any:
         params = efa_api.build_departure_params(
             verified, 10, stateless=stateless, language=q.language or "de"
         )
+        full_url = requests.Request(
+            "GET",
+            f"{efa_api.BASE_URL}/XML_DM_REQUEST",
+            params=params,
+        ).prepare().url
         request_logger.log_entry(
             {
                 "input": body.text,
                 "stop": point,
-                "url": f"{efa_api.BASE_URL}/XML_DM_REQUEST",
-                "params": params,
+                "url": full_url,
             }
         )
         data = efa_api.departure_monitor(
@@ -122,13 +127,17 @@ def search(body: SearchRequest, format: str = Query("json")) -> Any:
         datetime_mode=q.datetime_mode,
         language=q.language or "de",
     )
+    full_url = requests.Request(
+        "GET",
+        f"{efa_api.BASE_URL}/XML_TRIP_REQUEST2",
+        params=params,
+    ).prepare().url
     request_logger.log_entry(
         {
             "input": body.text,
             "from": from_point,
             "to": to_point,
-            "url": f"{efa_api.BASE_URL}/XML_TRIP_REQUEST2",
-            "params": params,
+            "url": full_url,
         }
     )
     data: Dict[str, Any] = efa_api.trip_request(
@@ -177,12 +186,16 @@ def departures(body: DeparturesRequest, format: str = Query("json")) -> Any:
     params = efa_api.build_departure_params(
         verified, body.limit, stateless=stateless, language=body.language
     )
+    full_url = requests.Request(
+        "GET",
+        f"{efa_api.BASE_URL}/XML_DM_REQUEST",
+        params=params,
+    ).prepare().url
     request_logger.log_entry(
         {
             "input": body.stop,
             "stop": point,
-            "url": f"{efa_api.BASE_URL}/XML_DM_REQUEST",
-            "params": params,
+            "url": full_url,
         }
     )
     data = efa_api.departure_monitor(
@@ -212,11 +225,15 @@ def stops(body: StopsRequest, format: str = Query("json")) -> Any:
         "outputFormat": "JSON",
         "language": body.language,
     }
+    full_url = requests.Request(
+        "GET",
+        f"{efa_api.BASE_URL}/XML_STOPFINDER_REQUEST",
+        params=params,
+    ).prepare().url
     request_logger.log_entry(
         {
             "input": body.query,
-            "url": f"{efa_api.BASE_URL}/XML_STOPFINDER_REQUEST",
-            "params": params,
+            "url": full_url,
         }
     )
     data = efa_api.stop_finder(body.query, language=body.language)


### PR DESCRIPTION
## Summary
- log complete request URLs in `efa_api` so the logs contain clickable links
- include the final URLs in FastAPI app request logs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a9a81dc083219421d2870b8f9f7f