### PR TITLE
Update transport mode params

### DIFF
--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -34,10 +34,14 @@ def build_trip_params(
         "language": language,
         "odvMacro": "true",
         "includedMeans": "checkbox",
-        "inclMOT_BUS": "true" if bus else "false",
-        "inclMOT_ZUG": "true" if zug else "false",
-        "inclMOT_8": "true" if seilbahn else "false",
     }
+
+    if bus:
+        params["inclMOT_BUS"] = "true"
+    if zug:
+        params["inclMOT_ZUG"] = "true"
+    if seilbahn:
+        params["inclMOT_8"] = "true"
     if origin_stateless:
         params["name_origin"] = origin_stateless
         params["type_origin"] = "stop"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -55,8 +55,36 @@ def test_build_trip_params_long_distance():
         language="it",
     )
     assert params["inclMOT_BUS"] == "true"
-    assert params["inclMOT_ZUG"] == "false"
-    assert params["inclMOT_8"] == "false"
+    assert "inclMOT_ZUG" not in params
+    assert "inclMOT_8" not in params
     assert params["lineRestriction"] == "401"
     assert params["itdTripDateTimeDepArr"] == "arr"
     assert params["language"] == "it"
+
+
+def test_build_trip_params_only_train():
+    params = efa_api.build_trip_params(
+        "A",
+        "B",
+        "2025-02-03T12:00",
+        bus=False,
+        zug=True,
+        seilbahn=False,
+    )
+    assert "inclMOT_BUS" not in params
+    assert params["inclMOT_ZUG"] == "true"
+    assert "inclMOT_8" not in params
+
+
+def test_build_trip_params_no_bus():
+    params = efa_api.build_trip_params(
+        "A",
+        "B",
+        "2025-02-03T12:00",
+        bus=False,
+        zug=True,
+        seilbahn=True,
+    )
+    assert "inclMOT_BUS" not in params
+    assert params["inclMOT_ZUG"] == "true"
+    assert params["inclMOT_8"] == "true"


### PR DESCRIPTION
## Summary
- only send `inclMOT_*` parameters when their mode is enabled
- update unit tests for new `build_trip_params` behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870afa0bc7c8321a6f06a3e0b257e17