### PR TITLE
Ensure null modes become defaults

### DIFF
--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -56,12 +56,12 @@ def build_trip_params(
         params["name_destination"] = destination
         params["type_destination"] = destination_type or "any"
 
+    params["itdTripDateTimeDepArr"] = datetime_mode
     if datetime:
         try:
             dt_value = dt.datetime.fromisoformat(datetime)
             params["itdDate"] = dt_value.strftime("%Y%m%d")
             params["itdTime"] = dt_value.strftime("%H:%M")
-            params["itdTripDateTimeDepArr"] = datetime_mode
         except ValueError:
             logger.warning("Invalid datetime string: %s", datetime)
 

--- a/src/llm_formatter.py
+++ b/src/llm_formatter.py
@@ -7,6 +7,21 @@ from typing import Any, Dict, List, Optional
 
 import openai
 
+NO_RESULTS = {
+    "de": (
+        "Keine Ergebnisse gefunden. Vielleicht gab es ein Problem bei der Eingabe. "
+        "Bitte versuche es mit einer anderen Formulierung."
+    ),
+    "it": (
+        "Nessun risultato trovato. Potrebbe esserci stato un problema nell'inserimento. "
+        "Prova con una nuova formulazione."
+    ),
+    "en": (
+        "No results found. Something may have gone wrong with the input. "
+        "Please try again with a different wording."
+    ),
+}
+
 from .config import get_openai_model, get_openai_max_tokens
 
 PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "formatter_prompt.txt"
@@ -139,11 +154,15 @@ def format_trip(
         model = get_openai_model()
     if max_tokens is None:
         max_tokens = get_openai_max_tokens()
+
+    short_data = extract_trip_info(data)
+    if not short_data:
+        return NO_RESULTS.get(language, NO_RESULTS["de"])
+
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
 
-    short_data = extract_trip_info(data)
     prompt = load_prompt().format(data=json.dumps(short_data, ensure_ascii=False), language=language)
 
     client = openai.OpenAI(api_key=api_key)
@@ -170,11 +189,15 @@ def format_departures(
         model = get_openai_model()
     if max_tokens is None:
         max_tokens = get_openai_max_tokens()
+
+    short_data = extract_departure_info(data)
+    if not short_data.get("departures"):
+        return NO_RESULTS.get(language, NO_RESULTS["de"])
+
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
 
-    short_data = extract_departure_info(data)
     prompt = load_prompt().format(data=json.dumps(short_data, ensure_ascii=False), language=language)
 
 

--- a/src/llm_parser.py
+++ b/src/llm_parser.py
@@ -64,15 +64,30 @@ def parse_llm(text: str, model: Optional[str] = None) -> Query:
     content = response.choices[0].message.content.strip()
     data = json.loads(content)
     data["datetime"] = _normalize_datetime(data.get("datetime"), text)
+
+    bus = data.get("bus", True)
+    if bus is None:
+        bus = True
+
+    zug = data.get("zug", True)
+    if zug is None:
+        zug = True
+
+    seilbahn = data.get("seilbahn", True)
+    if seilbahn is None:
+        seilbahn = True
+
+    datetime_mode = data.get("datetime_mode") or "dep"
+
     return Query(
         type=data.get("type", "unknown"),
         from_location=data.get("from"),
         to_location=data.get("to"),
         datetime=data.get("datetime"),
         language=data.get("language"),
-        bus=data.get("bus", True),
-        zug=data.get("zug", True),
-        seilbahn=data.get("seilbahn", True),
+        bus=bus,
+        zug=zug,
+        seilbahn=seilbahn,
         long_distance=data.get("long_distance", False),
-        datetime_mode=data.get("datetime_mode", "dep"),
+        datetime_mode=datetime_mode,
     )

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from src import llm_formatter
+
+
+def test_format_trip_no_results():
+    data = {"trips": None}
+    msg = llm_formatter.format_trip(data, language="en")
+    assert "No results found" in msg
+
+
+def test_format_departures_no_results():
+    data = {"departureList": None}
+    msg = llm_formatter.format_departures(data, language="de")
+    assert "Keine Ergebnisse" in msg

--- a/tests/test_llm_parser.py
+++ b/tests/test_llm_parser.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import json
+from types import SimpleNamespace
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from src.llm_parser import parse_llm
+import openai
+
+
+class DummyClient:
+    def __init__(self, response):
+        self._response = response
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **kwargs: self._response)
+        )
+
+
+def test_parse_llm_defaults(monkeypatch):
+    data = {
+        "type": "trip",
+        "from": "A",
+        "to": "B",
+        "datetime": "2025-07-11T10:38",
+        "language": "de",
+        "bus": None,
+        "zug": None,
+        "seilbahn": None,
+        "long_distance": False,
+        "datetime_mode": None,
+    }
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=json.dumps(data)))]
+    )
+    monkeypatch.setattr(openai, "OpenAI", lambda api_key=None: DummyClient(response))
+    os.environ["OPENAI_API_KEY"] = "test"
+    query = parse_llm("irrelevant")
+    assert query.bus is True
+    assert query.zug is True
+    assert query.seilbahn is True
+    assert query.datetime_mode == "dep"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -26,6 +26,13 @@ def test_parse_trip_simple():
     assert q.datetime == "2025-01-01T12:30"
 
 
+def test_parse_trip_default_modes():
+    q = parser.parse("von A nach B")
+    assert q.bus is True
+    assert q.zug is True
+    assert q.seilbahn is True
+
+
 def test_parse_departure():
     q = parser.parse("Abfahrten Bozen")
     assert q.type == "departure"
@@ -60,6 +67,14 @@ def test_build_trip_params_long_distance():
     assert params["lineRestriction"] == "401"
     assert params["itdTripDateTimeDepArr"] == "arr"
     assert params["language"] == "it"
+
+
+def test_build_trip_params_defaults():
+    params = efa_api.build_trip_params("A", "B")
+    assert params["inclMOT_BUS"] == "true"
+    assert params["inclMOT_ZUG"] == "true"
+    assert params["inclMOT_8"] == "true"
+    assert params["itdTripDateTimeDepArr"] == "dep"
 
 
 def test_build_trip_params_only_train():


### PR DESCRIPTION
## Summary
- handle null settings from the LLM parser
- test that null values result in enabled modes by default

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6870c7f7d0788321b8a7a628c6dc6f52