### PR TITLE
Add MCP server and refactor API logic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ langdetect
 python-telegram-bot
 python-dotenv
 openai
+mcp<1

--- a/src/main.py
+++ b/src/main.py
@@ -1,241 +1,32 @@
-"""FastAPI application for transport queries."""
+from typing import Any
 
-from typing import Any, Dict
+from fastapi import FastAPI, Query
 
-from fastapi import FastAPI, HTTPException, Query
-from pydantic import BaseModel
-import requests
-
-from . import efa_api, parser, llm_parser, llm_formatter, request_logger
+from .services import (
+    DeparturesRequest,
+    SearchRequest,
+    StopsRequest,
+    departures_service,
+    search_service,
+    stops_service,
+)
 
 app = FastAPI()
 
 
-class SearchRequest(BaseModel):
-    """Request body for /search."""
-
-    text: str
-
-
-class DeparturesRequest(BaseModel):
-    """Request body for /departures."""
-
-    stop: str
-    limit: int = 10
-    language: str = "de"
-
-
-class StopsRequest(BaseModel):
-    """Request body for /stops."""
-
-    query: str
-    language: str = "de"
-
-
 @app.post("/search")
 def search(body: SearchRequest, format: str = Query("json")) -> Any:
-    """Parse a text query and return EFA results.
-
-    A departure monitor request is executed when no destination is provided.
-    """
-    q = parser.parse(body.text)
-    if q.type != "trip" or not q.from_location or not q.to_location:
-        try:
-            q = llm_parser.parse_llm(body.text)
-        except Exception as exc:  # pragma: no cover - no tests
-            raise HTTPException(status_code=400, detail=str(exc))
-
-    if not q.from_location:
-        raise HTTPException(status_code=400, detail="origin not specified")
-
-    if not q.to_location:
-        sf_data = efa_api.stop_finder(q.from_location, language=q.language or "de")
-        points = sf_data.get("stopFinder", {}).get("points", [])
-        if not points:
-            raise HTTPException(status_code=404, detail="stop not found")
-        point = efa_api.best_point(points)
-        if not point:
-            raise HTTPException(status_code=404, detail="stop not found")
-        verified = point.get("name", q.from_location)
-        stateless = point.get("stateless")
-        params = efa_api.build_departure_params(
-            verified, 10, stateless=stateless, language=q.language or "de"
-        )
-        full_url = requests.Request(
-            "GET",
-            f"{efa_api.BASE_URL}/XML_DM_REQUEST",
-            params=params,
-        ).prepare().url
-        request_logger.log_entry(
-            {
-                "input": body.text,
-                "stop": point,
-                "url": full_url,
-            }
-        )
-        data = efa_api.departure_monitor(
-            verified, 10, stateless=stateless, language=q.language or "de"
-        )
-        short_data = llm_formatter.extract_departure_info(data)
-        try:
-            text = llm_formatter.format_departures(data, language=q.language or "de")
-            if format == "text":
-                return text
-            return {
-                "input": body.text,
-                "stop": point,
-                "llmData": short_data,
-                "data": text,
-            }
-        except Exception as exc:  # pragma: no cover - no tests
-            raise HTTPException(status_code=500, detail=str(exc))
-
-    from_data = efa_api.stop_finder(q.from_location, language=q.language or "de")
-    points = from_data.get("stopFinder", {}).get("points", [])
-    if not points:
-        raise HTTPException(status_code=404, detail="origin not found")
-    from_point = efa_api.best_point(points)
-    if not from_point:
-        raise HTTPException(status_code=404, detail="origin not found")
-    q.from_location = from_point.get("name", q.from_location)
-    from_stateless = from_point.get("stateless")
-    from_type = from_point.get("anyType")
-
-    to_data = efa_api.stop_finder(q.to_location, language=q.language or "de")
-    points = to_data.get("stopFinder", {}).get("points", [])
-    if not points:
-        raise HTTPException(status_code=404, detail="destination not found")
-    to_point = efa_api.best_point(points)
-    if not to_point:
-        raise HTTPException(status_code=404, detail="destination not found")
-    q.to_location = to_point.get("name", q.to_location)
-    to_stateless = to_point.get("stateless")
-    to_type = to_point.get("anyType")
-
-    params = efa_api.build_trip_params(
-        q.from_location,
-        q.to_location,
-        q.datetime,
-        origin_stateless=from_stateless,
-        destination_stateless=to_stateless,
-        origin_type=from_type,
-        destination_type=to_type,
-        bus=q.bus,
-        zug=q.zug,
-        seilbahn=q.seilbahn,
-        long_distance=q.long_distance,
-        datetime_mode=q.datetime_mode,
-        language=q.language or "de",
-    )
-    full_url = requests.Request(
-        "GET",
-        f"{efa_api.BASE_URL}/XML_TRIP_REQUEST2",
-        params=params,
-    ).prepare().url
-    request_logger.log_entry(
-        {
-            "input": body.text,
-            "from": from_point,
-            "to": to_point,
-            "url": full_url,
-        }
-    )
-    data: Dict[str, Any] = efa_api.trip_request(
-        q.from_location,
-        q.to_location,
-        q.datetime,
-        origin_stateless=from_stateless,
-        destination_stateless=to_stateless,
-        origin_type=from_type,
-        destination_type=to_type,
-        bus=q.bus,
-        zug=q.zug,
-        seilbahn=q.seilbahn,
-        long_distance=q.long_distance,
-        datetime_mode=q.datetime_mode,
-        language=q.language or "de",
-    )
-    short_data = llm_formatter.extract_trip_info(data)
-    try:
-        text = llm_formatter.format_trip(data, language=q.language or "de")
-        if format == "text":
-            return text
-        return {
-            "input": body.text,
-            "from": from_point,
-            "to": to_point,
-            "llmData": short_data,
-            "data": text,
-        }
-    except Exception as exc:  # pragma: no cover - no tests
-        raise HTTPException(status_code=500, detail=str(exc))
+    """Parse a text query and return EFA results."""
+    return search_service(body, format)
 
 
 @app.post("/departures")
 def departures(body: DeparturesRequest, format: str = Query("json")) -> Any:
     """Return upcoming departures for a stop."""
-    sf_data = efa_api.stop_finder(body.stop, language=body.language)
-    points = sf_data.get("stopFinder", {}).get("points", [])
-    if not points:
-        raise HTTPException(status_code=404, detail="stop not found")
-    point = efa_api.best_point(points)
-    if not point:
-        raise HTTPException(status_code=404, detail="stop not found")
-    verified = point.get("name", body.stop)
-    stateless = point.get("stateless")
-    params = efa_api.build_departure_params(
-        verified, body.limit, stateless=stateless, language=body.language
-    )
-    full_url = requests.Request(
-        "GET",
-        f"{efa_api.BASE_URL}/XML_DM_REQUEST",
-        params=params,
-    ).prepare().url
-    request_logger.log_entry(
-        {
-            "input": body.stop,
-            "stop": point,
-            "url": full_url,
-        }
-    )
-    data = efa_api.departure_monitor(
-        verified, body.limit, stateless=stateless, language=body.language
-    )
-    short_data = llm_formatter.extract_departure_info(data)
-    try:
-        text = llm_formatter.format_departures(data, language=body.language)
-        if format == "text":
-            return text
-        return {
-            "input": body.stop,
-            "stop": point,
-            "llmData": short_data,
-            "data": text,
-        }
-    except Exception as exc:  # pragma: no cover - no tests
-        raise HTTPException(status_code=500, detail=str(exc))
+    return departures_service(body, format)
 
 
 @app.post("/stops")
 def stops(body: StopsRequest, format: str = Query("json")) -> Any:
     """Return stop name suggestions."""
-    params = {
-        "name_sf": body.query,
-        "odvSugMacro": "true",
-        "outputFormat": "JSON",
-        "language": body.language,
-    }
-    full_url = requests.Request(
-        "GET",
-        f"{efa_api.BASE_URL}/XML_STOPFINDER_REQUEST",
-        params=params,
-    ).prepare().url
-    request_logger.log_entry(
-        {
-            "input": body.query,
-            "url": full_url,
-        }
-    )
-    data = efa_api.stop_finder(body.query, language=body.language)
-    return data if format == "text" else {"data": data}
-
+    return stops_service(body, format)

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1,0 +1,67 @@
+"""Model Context Protocol server exposing transport tools."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Sequence, List
+
+import json
+from mcp import types
+from mcp.server import Server
+
+from .services import (
+    DeparturesRequest,
+    SearchRequest,
+    StopsRequest,
+    departures_service,
+    search_service,
+    stops_service,
+)
+
+server = Server("suedtirolmobilAI")
+
+
+@server.list_tools()
+async def list_tools() -> List[types.Tool]:
+    """Expose available transport tools."""
+    return [
+        types.Tool(
+            name="search",
+            description="Parse a text query and return EFA results",
+            inputSchema=SearchRequest.model_json_schema(),
+        ),
+        types.Tool(
+            name="departures",
+            description="Return upcoming departures for a stop",
+            inputSchema=DeparturesRequest.model_json_schema(),
+        ),
+        types.Tool(
+            name="stops",
+            description="Return stop name suggestions",
+            inputSchema=StopsRequest.model_json_schema(),
+        ),
+    ]
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: Dict[str, Any]) -> Sequence[types.TextContent]:
+    """Dispatch tool calls to the service layer."""
+    args = dict(arguments)
+    fmt = args.pop("format", "json")
+    if name == "search":
+        result = search_service(SearchRequest(**args), fmt)
+    elif name == "departures":
+        result = departures_service(DeparturesRequest(**args), fmt)
+    elif name == "stops":
+        result = stops_service(StopsRequest(**args), fmt)
+    else:
+        raise ValueError(f"Unknown tool: {name}")
+
+    text = result if isinstance(result, str) else json.dumps(result)
+    return [types.TextContent(type="text", text=text)]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual start
+    import asyncio
+    from mcp.server import stdio_server
+
+    asyncio.run(stdio_server.run(server))

--- a/src/services.py
+++ b/src/services.py
@@ -1,0 +1,235 @@
+"""Service layer for transit queries."""
+from typing import Any, Dict
+
+import requests
+from fastapi import HTTPException
+from pydantic import BaseModel
+
+from . import efa_api, parser, llm_parser, llm_formatter, request_logger
+
+
+class SearchRequest(BaseModel):
+    """Request body for search queries."""
+
+    text: str
+
+
+class DeparturesRequest(BaseModel):
+    """Request body for departures queries."""
+
+    stop: str
+    limit: int = 10
+    language: str = "de"
+
+
+class StopsRequest(BaseModel):
+    """Request body for stop suggestions."""
+
+    query: str
+    language: str = "de"
+
+
+def search_service(body: SearchRequest, format: str = "json") -> Any:
+    """Parse a text query and return EFA results.
+
+    A departure monitor request is executed when no destination is provided.
+    """
+    q = parser.parse(body.text)
+    if q.type != "trip" or not q.from_location or not q.to_location:
+        try:
+            q = llm_parser.parse_llm(body.text)
+        except Exception as exc:  # pragma: no cover - no tests
+            raise HTTPException(status_code=400, detail=str(exc))
+
+    if not q.from_location:
+        raise HTTPException(status_code=400, detail="origin not specified")
+
+    if not q.to_location:
+        sf_data = efa_api.stop_finder(q.from_location, language=q.language or "de")
+        points = sf_data.get("stopFinder", {}).get("points", [])
+        if not points:
+            raise HTTPException(status_code=404, detail="stop not found")
+        point = efa_api.best_point(points)
+        if not point:
+            raise HTTPException(status_code=404, detail="stop not found")
+        verified = point.get("name", q.from_location)
+        stateless = point.get("stateless")
+        params = efa_api.build_departure_params(
+            verified, 10, stateless=stateless, language=q.language or "de"
+        )
+        full_url = requests.Request(
+            "GET",
+            f"{efa_api.BASE_URL}/XML_DM_REQUEST",
+            params=params,
+        ).prepare().url
+        request_logger.log_entry(
+            {
+                "input": body.text,
+                "stop": point,
+                "url": full_url,
+            }
+        )
+        data = efa_api.departure_monitor(
+            verified, 10, stateless=stateless, language=q.language or "de"
+        )
+        short_data = llm_formatter.extract_departure_info(data)
+        try:
+            text = llm_formatter.format_departures(data, language=q.language or "de")
+            if format == "text":
+                return text
+            return {
+                "input": body.text,
+                "stop": point,
+                "llmData": short_data,
+                "data": text,
+            }
+        except Exception as exc:  # pragma: no cover - no tests
+            raise HTTPException(status_code=500, detail=str(exc))
+
+    from_data = efa_api.stop_finder(q.from_location, language=q.language or "de")
+    points = from_data.get("stopFinder", {}).get("points", [])
+    if not points:
+        raise HTTPException(status_code=404, detail="origin not found")
+    from_point = efa_api.best_point(points)
+    if not from_point:
+        raise HTTPException(status_code=404, detail="origin not found")
+    q.from_location = from_point.get("name", q.from_location)
+    from_stateless = from_point.get("stateless")
+    from_type = from_point.get("anyType")
+
+    to_data = efa_api.stop_finder(q.to_location, language=q.language or "de")
+    points = to_data.get("stopFinder", {}).get("points", [])
+    if not points:
+        raise HTTPException(status_code=404, detail="destination not found")
+    to_point = efa_api.best_point(points)
+    if not to_point:
+        raise HTTPException(status_code=404, detail="destination not found")
+    q.to_location = to_point.get("name", q.to_location)
+    to_stateless = to_point.get("stateless")
+    to_type = to_point.get("anyType")
+
+    params = efa_api.build_trip_params(
+        q.from_location,
+        q.to_location,
+        q.datetime,
+        origin_stateless=from_stateless,
+        destination_stateless=to_stateless,
+        origin_type=from_type,
+        destination_type=to_type,
+        bus=q.bus,
+        zug=q.zug,
+        seilbahn=q.seilbahn,
+        long_distance=q.long_distance,
+        datetime_mode=q.datetime_mode,
+        language=q.language or "de",
+    )
+    full_url = requests.Request(
+        "GET",
+        f"{efa_api.BASE_URL}/XML_TRIP_REQUEST2",
+        params=params,
+    ).prepare().url
+    request_logger.log_entry(
+        {
+            "input": body.text,
+            "from": from_point,
+            "to": to_point,
+            "url": full_url,
+        }
+    )
+    data: Dict[str, Any] = efa_api.trip_request(
+        q.from_location,
+        q.to_location,
+        q.datetime,
+        origin_stateless=from_stateless,
+        destination_stateless=to_stateless,
+        origin_type=from_type,
+        destination_type=to_type,
+        bus=q.bus,
+        zug=q.zug,
+        seilbahn=q.seilbahn,
+        long_distance=q.long_distance,
+        datetime_mode=q.datetime_mode,
+        language=q.language or "de",
+    )
+    short_data = llm_formatter.extract_trip_info(data)
+    try:
+        text = llm_formatter.format_trip(data, language=q.language or "de")
+        if format == "text":
+            return text
+        return {
+            "input": body.text,
+            "from": from_point,
+            "to": to_point,
+            "llmData": short_data,
+            "data": text,
+        }
+    except Exception as exc:  # pragma: no cover - no tests
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+def departures_service(body: DeparturesRequest, format: str = "json") -> Any:
+    """Return upcoming departures for a stop."""
+    sf_data = efa_api.stop_finder(body.stop, language=body.language)
+    points = sf_data.get("stopFinder", {}).get("points", [])
+    if not points:
+        raise HTTPException(status_code=404, detail="stop not found")
+    point = efa_api.best_point(points)
+    if not point:
+        raise HTTPException(status_code=404, detail="stop not found")
+    verified = point.get("name", body.stop)
+    stateless = point.get("stateless")
+    params = efa_api.build_departure_params(
+        verified, body.limit, stateless=stateless, language=body.language
+    )
+    full_url = requests.Request(
+        "GET",
+        f"{efa_api.BASE_URL}/XML_DM_REQUEST",
+        params=params,
+    ).prepare().url
+    request_logger.log_entry(
+        {
+            "input": body.stop,
+            "stop": point,
+            "url": full_url,
+        }
+    )
+    data = efa_api.departure_monitor(
+        verified, body.limit, stateless=stateless, language=body.language
+    )
+    short_data = llm_formatter.extract_departure_info(data)
+    try:
+        text = llm_formatter.format_departures(data, language=body.language)
+        if format == "text":
+            return text
+        return {
+            "input": body.stop,
+            "stop": point,
+            "llmData": short_data,
+            "data": text,
+        }
+    except Exception as exc:  # pragma: no cover - no tests
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+def stops_service(body: StopsRequest, format: str = "json") -> Any:
+    """Return stop name suggestions."""
+    params = {
+        "name_sf": body.query,
+        "odvSugMacro": "true",
+        "outputFormat": "JSON",
+        "language": body.language,
+    }
+    full_url = requests.Request(
+        "GET",
+        f"{efa_api.BASE_URL}/XML_STOPFINDER_REQUEST",
+        params=params,
+    ).prepare().url
+    request_logger.log_entry(
+        {
+            "input": body.query,
+            "url": full_url,
+        }
+    )
+    data = efa_api.stop_finder(body.query, language=body.language)
+    return data if format == "text" else {"data": data}
+


### PR DESCRIPTION
## Summary
- introduce MCP server exposing search, departures and stops tools
- move transport query logic into reusable service layer
- lighten FastAPI app and add MCP dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899cd7e4b84832185e65f1982d118b9