### PR TITLE
Add MCP server config and documentation

### DIFF
--- a/docs/EFA_XML_API.md
+++ b/docs/EFA_XML_API.md
@@ -125,6 +125,12 @@ The EFA XML-API allows access to various public transport functions via HTTP req
 - **Official Documentation**:  
   https://data.civis.bz.it/dataset/575f7455-6447-4626-a474-0f93ff03067b/resource/c4e66cdf-7749-40ad-bcfd-179f18743d84/download/dokumentationxmlschnittstelleapbv32014-08-28.pdf
 
-- **Similar APIs**:  
-  - Linz: http://data.linz.gv.at/katalog/linz_ag/linz_ag_linien/fahrplan/LINZ_LINIEN_Schnittstelle_EFA_V1.pdf  
+- **Similar APIs**:
+  - Linz: http://data.linz.gv.at/katalog/linz_ag/linz_ag_linien/fahrplan/LINZ_LINIEN_Schnittstelle_EFA_V1.pdf
   - London: http://content.tfl.gov.uk/journey-planner-api-documentation.pdf
+
+## MCP Server
+
+This project also exposes the transport functions via a Model Context Protocol (MCP) server.
+Start the server with `python -m src.mcp_server` and configure it through the
+`MCP_SERVER_PORT` and `MCP_AUTH_TOKEN` environment variables.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ python-telegram-bot
 python-dotenv
 openai
 mcp<1
+mcp-server

--- a/src/config.py
+++ b/src/config.py
@@ -22,3 +22,24 @@ def get_openai_max_tokens(default: int = 100) -> int:
     if value and value.isdigit():
         return int(value)
     return default
+
+
+def get_mcp_port(default: int = 8080) -> int:
+    """Return the port for the MCP server.
+
+    The value is taken from the ``MCP_SERVER_PORT`` environment variable and
+    falls back to ``default`` when not set or invalid.
+    """
+    value = os.getenv("MCP_SERVER_PORT")
+    if value and value.isdigit():
+        return int(value)
+    return default
+
+
+def get_mcp_auth_token() -> str:
+    """Return the authentication token for the MCP server.
+
+    The value is taken from the ``MCP_AUTH_TOKEN`` environment variable and
+    defaults to an empty string.
+    """
+    return os.getenv("MCP_AUTH_TOKEN", "")


### PR DESCRIPTION
## Summary
- include `mcp-server` dependency
- provide helpers for MCP server port and auth token
- document MCP server setup and environment variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899f9d6a5048321a47d00a69f393dff