### PR TITLE
Add mcp dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ langdetect
 python-telegram-bot
 python-dotenv
 openai
+
+mcp>=1.12.4


### PR DESCRIPTION
## Summary
- add mcp>=1.12.4 to project requirements

## Testing
- `pip install -r requirements.txt` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'CHANGELOG.md')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcp')*
- `systemctl restart suedtirolmobilai.service` *(fails: System has not been booted with systemd as init system (PID 1). Can't operate.)*

------
https://chatgpt.com/codex/tasks/task_e_689a04c979848321a9b1dc067336d145