### PR TITLE
Add mcp dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,15 @@ fastapi
 requests
 spacy<3.8
 pydantic
-uvicorn<0.19
+uvicorn>=0.18,<0.19; python_version < "3.10"
+uvicorn>=0.23.1; python_version >= "3.10"
 pytest
-httpx<0.25
+httpx<0.25; python_version < "3.10"
+httpx>=0.27,<0.29; python_version >= "3.10"
 langdetect
-python-telegram-bot
+python-telegram-bot<21; python_version < "3.10"
+python-telegram-bot>=22.3; python_version >= "3.10"
 python-dotenv
 openai
+
+mcp>=1.12.4; python_version >= "3.10"


### PR DESCRIPTION
## Summary
- add mcp>=1.12.4 for Python 3.10+ and adjust related dependency markers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `systemctl restart suedtirolmobilai.service` *(fails: System has not been booted with systemd as init system)*

------
https://chatgpt.com/codex/tasks/task_e_689a04c979848321a9b1dc067336d145