### PR TITLE
Replace include/exclude with transport flags

### DIFF
--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -184,9 +184,11 @@ def merge_queries(old: parser.Query, new: parser.Query) -> parser.Query:
         new.to_location or old.to_location,
         new.datetime or old.datetime,
         new.language or old.language,
-        new.include if new.include is not None else old.include,
-        new.exclude if new.exclude is not None else old.exclude,
-        new.long_distance or old.long_distance,
+        new.bus if new.bus is not None else old.bus,
+        new.zug if new.zug is not None else old.zug,
+        new.seilbahn if new.seilbahn is not None else old.seilbahn,
+        new.long_distance if new.long_distance is not None else old.long_distance,
+        new.datetime_mode if new.datetime_mode is not None else old.datetime_mode,
     )
 
 


### PR DESCRIPTION
## Summary
- merge query parameters using transport-mode flags (bus, zug, seilbahn) and long-distance/datetime mode
- support overriding of each flag when merging user queries

## Testing
- `python - <<'PY'
from src import parser
from src.telegram_bot import merge_queries
base = parser.parse("von bozen nach meran")
q1 = parser.parse("ohne bus")
merged1 = merge_queries(base, q1)
q2 = parser.parse("nur zug")
merged2 = merge_queries(base, q2)
print(base)
print(q1)
print(merged1)
print(q2)
print(merged2)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b1952e708832199020a575b70e6bc