### PR TITLE
Add support for last connection queries

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -65,6 +65,7 @@ def main() -> None:
                     seilbahn=q.seilbahn,
                     long_distance=q.long_distance,
                     datetime_mode=q.datetime_mode,
+                    last_connection=q.last_connection,
                     language=q.language or "de",
                 )
                 debug_info["request"] = {
@@ -85,6 +86,7 @@ def main() -> None:
                 seilbahn=q.seilbahn,
                 long_distance=q.long_distance,
                 datetime_mode=q.datetime_mode,
+                last_connection=q.last_connection,
                 language=q.language or "de",
             )
             if args.llm_format:

--- a/src/efa_api.py
+++ b/src/efa_api.py
@@ -26,9 +26,15 @@ def build_trip_params(
     seilbahn: bool = True,
     long_distance: Optional[bool] = None,
     datetime_mode: str = "dep",
+    last_connection: bool = False,
     language: str = "de",
 ) -> Dict[str, Any]:
-    """Return parameters for a trip request."""
+    """Return parameters for a trip request.
+
+    If ``last_connection`` is ``True``, the API is asked for the latest
+    possible connection of the day by setting ``calcMode`` to ``"last"`` and
+    defaulting the time to ``23:59`` when no explicit datetime is supplied.
+    """
     params: Dict[str, Any] = {
         "outputFormat": "JSON",
         "language": language,
@@ -64,6 +70,13 @@ def build_trip_params(
             params["itdTime"] = dt_value.strftime("%H:%M")
         except ValueError:
             logger.warning("Invalid datetime string: %s", datetime)
+    elif last_connection:
+        now = dt.datetime.now()
+        params["itdDate"] = now.strftime("%Y%m%d")
+        params["itdTime"] = "23:59"
+
+    if last_connection:
+        params["calcMode"] = "last"
 
     if long_distance is False:
         params["lineRestriction"] = "401"
@@ -109,6 +122,7 @@ def trip_request(
     seilbahn: bool = True,
     long_distance: Optional[bool] = None,
     datetime_mode: str = "dep",
+    last_connection: bool = False,
     language: str = "de",
 ) -> Dict[str, Any]:
     """Request a trip from origin to destination."""
@@ -125,6 +139,7 @@ def trip_request(
         seilbahn=seilbahn,
         long_distance=long_distance,
         datetime_mode=datetime_mode,
+        last_connection=last_connection,
         language=language,
     )
     url = f"{BASE_URL}/XML_TRIP_REQUEST2"

--- a/src/parser.py
+++ b/src/parser.py
@@ -20,7 +20,8 @@ class Query:
 
     ``bus``, ``zug`` and ``seilbahn`` toggle the respective transport modes.
     ``datetime_mode`` controls whether ``datetime`` refers to a departure
-    (``"dep"``) or arrival time (``"arr"").
+    (``"dep"``) or arrival time (``"arr"``). ``last_connection`` indicates
+    that the user is interested in the last possible connection of the day.
     """
 
     type: str
@@ -33,6 +34,7 @@ class Query:
     seilbahn: bool = True
     long_distance: Optional[bool] = False
     datetime_mode: str = "dep"
+    last_connection: bool = False
 
 
 # relative date keywords
@@ -66,6 +68,8 @@ LONG_DISTANCE_TERMS = {
     "longdistance",
     "lunga distanza",
 }
+
+LAST_CONNECTION_WORDS = {"letzte verbindung", "last connection", "ultima corsa"}
 
 
 TODAY_WORDS = {"heute", "today", "oggi"}
@@ -252,6 +256,7 @@ def parse(text: str) -> Query:
     seilbahn_explicit = False
     long_distance_explicit = False
     datetime_mode = "arr" if any(w in lower for w in ARRIVAL_WORDS) else "dep"
+    last_connection = any(w in lower for w in LAST_CONNECTION_WORDS)
 
     for w in WITHOUT_WORDS:
         if any(f"{w} {t}" in lower for t in BUS_TERMS):
@@ -351,6 +356,7 @@ def parse(text: str) -> Query:
             seilbahn=seilbahn,
             long_distance=long_distance,
             datetime_mode=datetime_mode,
+            last_connection=last_connection,
         )
 
     match = TRIP_RE.search(text)
@@ -375,6 +381,7 @@ def parse(text: str) -> Query:
             seilbahn=seilbahn,
             long_distance=long_distance,
             datetime_mode=datetime_mode,
+            last_connection=last_connection,
         )
 
     match = DEPT_RE.search(text)
@@ -388,6 +395,7 @@ def parse(text: str) -> Query:
             seilbahn=seilbahn,
             long_distance=long_distance,
             datetime_mode=datetime_mode,
+            last_connection=last_connection,
         )
 
     return Query(
@@ -398,4 +406,5 @@ def parse(text: str) -> Query:
         seilbahn=seilbahn,
         long_distance=long_distance,
         datetime_mode=datetime_mode,
+        last_connection=last_connection,
     )

--- a/src/services.py
+++ b/src/services.py
@@ -44,6 +44,7 @@ class TripRequest(BaseModel):
     seilbahn: bool = True
     long_distance: Optional[bool] = None
     datetime_mode: str = "dep"
+    last_connection: bool = False
     language: str = "de"
 
 
@@ -155,6 +156,7 @@ def search_service(body: SearchRequest, format: str = "json") -> Any:
         seilbahn=q.seilbahn,
         long_distance=q.long_distance,
         datetime_mode=q.datetime_mode,
+        last_connection=q.last_connection,
         language=q.language or "de",
     )
     full_url = requests.Request(
@@ -183,6 +185,7 @@ def search_service(body: SearchRequest, format: str = "json") -> Any:
         seilbahn=q.seilbahn,
         long_distance=q.long_distance,
         datetime_mode=q.datetime_mode,
+        last_connection=q.last_connection,
         language=q.language or "de",
     )
     short_data = llm_formatter.extract_trip_info(data)
@@ -283,6 +286,7 @@ def trip_service(body: TripRequest) -> Dict[str, Any]:
         seilbahn=body.seilbahn,
         long_distance=body.long_distance,
         datetime_mode=body.datetime_mode,
+        last_connection=body.last_connection,
         language=body.language,
     )
     full_url = requests.Request(
@@ -305,6 +309,7 @@ def trip_service(body: TripRequest) -> Dict[str, Any]:
             seilbahn=body.seilbahn,
             long_distance=body.long_distance,
             datetime_mode=body.datetime_mode,
+            last_connection=body.last_connection,
             language=body.language,
         )
     except requests.HTTPError as exc:  # pragma: no cover - network errors

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -113,6 +113,7 @@ def gather_debug_entries(text: str, state: str = None) -> List[Dict[str, Any]]:
                 seilbahn=query.seilbahn,
                 long_distance=query.long_distance,
                 datetime_mode=query.datetime_mode,
+                last_connection=query.last_connection,
                 language=query.language or "de",
             )
             entries.append(

--- a/tests/test_last_connection.py
+++ b/tests/test_last_connection.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from src import parser, efa_api
+
+
+@pytest.mark.parametrize("text", [
+    "Letzte Verbindung von A nach B",
+    "Last connection from A to B",
+    "Ultima corsa da A a B",
+])
+def test_parser_last_connection(text):
+    q = parser.parse(text)
+    assert q.last_connection is True
+
+
+def test_build_trip_params_last_connection():
+    params = efa_api.build_trip_params("A", "B", last_connection=True)
+    assert params.get("calcMode") == "last"
+    assert params.get("itdTime") == "23:59"


### PR DESCRIPTION
## Summary
- detect "letzte Verbindung" phrases and mark queries with `last_connection`
- forward `last_connection` into EFA request parameters using `calcMode=last`
- add tests for new parser and API behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b1956a46883219247f2be96008fe3