### PR TITLE
Improve Telegram bot error handling

### DIFF
--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -39,7 +39,10 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 async def call_api(
     command: str, session_id: str, text: str, *, json_response: bool = False
 ) -> Any:
-    """Call an MCP tool over WebSocket and return the response."""
+    """Call an MCP tool via WebSocket.
+
+    A user-friendly message is returned if the API server is unreachable.
+    """
     payload = {"session_id": session_id, "text": text}
     try:
         async with websocket_client(API_URL) as (read, write):
@@ -48,7 +51,7 @@ async def call_api(
             result = await session.call_tool(command.lstrip("/"), payload)
     except Exception as exc:  # pragma: no cover - network
         logger.error("Request failed: %s", exc)
-        return str(exc)
+        return "Service temporarily unavailable. Please try again later."
 
     texts = [c.text for c in result.content if hasattr(c, "text")]
     combined = "\n".join(texts)

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import types
+from contextlib import asynccontextmanager
+
+import anyio
+
+@asynccontextmanager
+async def failing_ws(*args, **kwargs):
+    raise ConnectionError("boom")
+    yield
+
+
+def test_call_api_connection_error(monkeypatch):
+    monkeypatch.setitem(sys.modules, "mcp.client.websocket", types.SimpleNamespace(websocket_client=failing_ws))
+    sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+    from src import telegram_bot
+    result = anyio.run(lambda: telegram_bot.call_api("/search", "1", "test"))
+    assert "service temporarily unavailable" in result.lower()


### PR DESCRIPTION
## Summary
- Return a user-friendly message when the Telegram bot can't reach the MCP server
- Test bot API call behavior on connection failure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a336410bf48321a488689ea4142005