### PR TITLE
Use HTTP server by default and expose MCP tools

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,23 @@
+"""FastAPI application exposing transport tools."""
+
+from typing import Any, Dict, List
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import PlainTextResponse
+
+from .mcp_server import server
+
+app = FastAPI()
+
+
+@app.post("/{tool_name}", response_class=PlainTextResponse)
+async def call_tool(tool_name: str, payload: Dict[str, Any]) -> str:
+    """Invoke an MCP tool and return its text output."""
+    if server._call_tool_fn is None:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail="server not initialized")
+    try:
+        result = await server._call_tool_fn(tool_name, payload)
+    except Exception as exc:  # pragma: no cover - runtime
+        raise HTTPException(status_code=500, detail=str(exc))
+    texts: List[str] = [getattr(item, "text", "") for item in result]
+    return "\n".join(texts)

--- a/src/stubs/__init__.py
+++ b/src/stubs/__init__.py
@@ -6,11 +6,17 @@ import them without the real dependencies being installed.
 """
 
 from importlib import import_module, util
+import os
 import sys
 
-# Always provide stubs for these modules to avoid pulling in heavy
-# dependencies or performing network operations during tests.
-for _name in ("fastapi", "openai", "requests"):
+# ``fastapi`` is only stubbed when the real package is not explicitly
+# requested.  This allows the development server to use the actual
+# implementation by setting ``USE_REAL_FASTAPI=1``.
+_base_stubs = ["openai", "requests"]
+if not os.getenv("USE_REAL_FASTAPI"):
+    _base_stubs.insert(0, "fastapi")
+
+for _name in _base_stubs:
     _module = import_module(f".{_name}", __name__)
     sys.modules[_name] = _module
 

--- a/start_bot.sh
+++ b/start_bot.sh
@@ -12,7 +12,7 @@ fi
 source venv/bin/activate
 
 TOKEN="${TELEGRAM_TOKEN}"
-API_URL="${API_URL:-ws://localhost:8000}"
+API_URL="${API_URL:-http://localhost:8000}"
 
 if [ -z "$TOKEN" ]; then
     echo "TELEGRAM_TOKEN must be set in .env" >&2
@@ -21,7 +21,7 @@ if [ -z "$TOKEN" ]; then
     exit 1
 fi
 
-python -m src.mcp_server &
+USE_REAL_FASTAPI=1 uvicorn src.main:app --port 8000 &
 SERVER_PID=$!
 trap "kill $SERVER_PID" EXIT
 


### PR DESCRIPTION
## Summary
- Default the bot's API_URL to `http://` and launch a local HTTP server via uvicorn
- Provide a minimal FastAPI app to expose MCP transport tools
- Allow bypassing FastAPI stubs by setting `USE_REAL_FASTAPI`

## Testing
- `pytest -q`
- `USE_REAL_FASTAPI=1 uvicorn src.main:app --port 8000 &` then `curl -s -X POST http://localhost:8000/reset_session -H 'Content-Type: application/json' -d '{"session_id": "1"}' && echo`

------
https://chatgpt.com/codex/tasks/task_e_68a4754d061c8321a63c2be6317d371a