### PR TITLE
Integrate MCP data retrieval into chat responses

### DIFF
--- a/src/conversation.py
+++ b/src/conversation.py
@@ -1,0 +1,74 @@
+"""ChatGPT interaction helpers using the MCP server."""
+
+from typing import Callable, Dict, List, Optional
+import os
+import openai
+
+from .config import get_openai_model, get_openai_max_tokens
+
+
+# Keywords that should trigger an MCP call
+MCP_KEYWORDS = {"departures", "departure", "trip", "stops", "stop"}
+
+
+def call_mcp(text: str) -> str:  # pragma: no cover - real network call
+    """Return data from the MCP server for ``text``.
+
+    The default implementation is a placeholder that should be replaced by a
+    real MCP client.  Tests monkeypatch this function.
+    """
+    raise RuntimeError("MCP client not configured")
+
+
+def _needs_mcp(text: str) -> bool:
+    """Return ``True`` if ``text`` indicates that MCP data is required."""
+    lower = text.lower()
+    return any(keyword in lower for keyword in MCP_KEYWORDS)
+
+
+def respond(
+    messages: List[Dict[str, str]],
+    *,
+    call_mcp_fn: Callable[[str], str] = call_mcp,
+    model: Optional[str] = None,
+    max_tokens: Optional[int] = None,
+) -> str:
+    """Return a ChatGPT response for ``messages``.
+
+    ``messages`` should be a list of chat messages compatible with the OpenAI
+    Chat Completions API.  The last message is assumed to contain the user's
+    latest request.  When simple heuristics indicate that MCP data could
+    improve the answer, ``call_mcp_fn`` is invoked with that text.  The
+    returned information is appended to the conversation as a system message
+    before querying ChatGPT.  Any network errors from the MCP call result in a
+    user friendly fallback message.
+    """
+    if not messages:
+        return ""
+
+    if model is None:
+        model = get_openai_model()
+    if max_tokens is None:
+        max_tokens = get_openai_max_tokens()
+
+    last_text = messages[-1].get("content", "")
+    if _needs_mcp(last_text):
+        try:
+            data = call_mcp_fn(last_text)
+        except Exception:  # pragma: no cover - network
+            return "Service temporarily unavailable. Please try again later."
+        messages = list(messages) + [
+            {"role": "system", "content": f"MCP data:\n{data}"}
+        ]
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set")
+
+    client = openai.OpenAI(api_key=api_key)
+    response = client.chat.completions.create(
+        model=model,
+        messages=messages,
+        max_tokens=max_tokens,
+    )
+    return response.choices[0].message.content.strip()

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,0 +1,53 @@
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+import openai
+from src import conversation
+
+
+class DummyClient:
+    def __init__(self, capture, content="ok"):
+        self._capture = capture
+        self._response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+        )
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(create=self._create)
+        )
+
+    def _create(self, **kwargs):
+        self._capture["messages"] = kwargs.get("messages")
+        return self._response
+
+
+def test_respond_invokes_mcp(monkeypatch):
+    capture = {}
+
+    def fake_call_mcp(text: str) -> str:
+        capture["called"] = True
+        return "MCP RESULT"
+
+    monkeypatch.setattr(conversation.openai, "OpenAI", lambda api_key=None: DummyClient(capture))
+    os.environ["OPENAI_API_KEY"] = "test"
+    messages = [{"role": "user", "content": "show departures for Bolzano"}]
+    result = conversation.respond(messages, call_mcp_fn=fake_call_mcp)
+    assert result == "ok"
+    assert capture.get("called") is True
+    assert any("MCP RESULT" in m["content"] for m in capture["messages"])
+
+
+def test_respond_mcp_failure(monkeypatch):
+    def failing_call_mcp(text: str) -> str:
+        raise ConnectionError("boom")
+
+    def fail_openai(*args, **kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("openai should not be called")
+
+    monkeypatch.setattr(conversation.openai, "OpenAI", fail_openai)
+    os.environ["OPENAI_API_KEY"] = "test"
+    messages = [{"role": "user", "content": "show departures"}]
+    result = conversation.respond(messages, call_mcp_fn=failing_call_mcp)
+    assert "temporarily unavailable" in result.lower()


### PR DESCRIPTION
## Summary
- add conversation helper with heuristic MCP integration and friendly error handling
- test conversation paths including MCP invocation and network failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a640e12a6c8321b2a23a4528d4af1b