### PR TITLE
Add OpenAI chat completions stub

### DIFF
--- a/src/stubs/openai.py
+++ b/src/stubs/openai.py
@@ -7,7 +7,35 @@ dependency.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import Any, List, Dict
+
+
+class ChatCompletions:
+    """Minimal chat completions handler."""
+
+    def __init__(self) -> None:
+        # ``client.chat.completions.create`` and ``client.chat.create`` both
+        # resolve to this instance.
+        self.completions = self
+
+    def create(self, *args: Any, **kwargs: Any) -> SimpleNamespace:
+        """Return a dummy response echoing the last message content.
+
+        Parameters are accepted for interface compatibility.  The returned
+        object mimics the structure accessed in ``choices[0].message.content``.
+        """
+
+        messages: List[Dict[str, str]] = kwargs.get("messages", [])
+        content = messages[-1]["content"] if messages else ""
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+        )
+
 
 class OpenAI:  # pragma: no cover - behaviour replaced in tests
-    def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - trivial
-        pass
+    """Minimal stand-in for :class:`openai.OpenAI`."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the stub client."""
+        self.chat = ChatCompletions()


### PR DESCRIPTION
## Summary
- stub out ChatCompletions with create method returning simple namespace
- expose chat handler in OpenAI client to avoid real API calls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a640e8073483219ae1c6f4788bfec4