### PR TITLE
Add normalization schemas and test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run pytest
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.coverage
+coverage.xml
+htmlcov/
+.pytest_cache/
+.venv/
+.env/
+build/
+dist/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # suedtirolmobilAI
+
+Utilities for normalising responses coming from the Südtirol EFA (Elektronische Fahrplanauskunft) backend. The project exposes helper functions that transform raw stop finder and departure monitor payloads into application level Pydantic models.
+
+## Development
+
+The project uses [poetry? no], we use `pyproject.toml` with setuptools. To work on the project create a virtual environment and install the package in editable mode with the development extras:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+```
+
+## Running the test suite
+
+Recorded fixtures for the EFA backend live under `tests/fixtures`. Tests validate the normalised outputs against the Pydantic schemas and assert contract behaviour for:
+
+- stop finder responses,
+- departures versus arrivals monitors,
+- realtime delay handling,
+- error mapping.
+
+Execute the full suite with:
+
+```bash
+pytest
+```
+
+## Continuous Integration
+
+A GitHub Actions workflow is provided at `.github/workflows/tests.yml`. It installs the package with development dependencies and runs the `pytest` suite on every push and pull request.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "suedtirolmobilai"
+version = "0.1.0"
+description = "Utilities for normalizing EFA responses for suedtirolmobil.ai"
+readme = "README.md"
+authors = [{name = "SuedtirolmobilAI Maintainers"}]
+requires-python = ">=3.10"
+dependencies = [
+    "pydantic>=2.5,<3.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4",
+    "pytest-cov>=4.1",
+]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "--maxfail=1 --disable-warnings"
+testpaths = ["tests"]

--- a/src/suedtirolmobilai/__init__.py
+++ b/src/suedtirolmobilai/__init__.py
@@ -1,0 +1,11 @@
+"""Core normalization utilities for EFA responses used by suedtirolmobil.ai."""
+
+from .handlers import map_error_response, normalize_departure_monitor, normalize_stop_finder
+from . import schemas
+
+__all__ = [
+    "map_error_response",
+    "normalize_departure_monitor",
+    "normalize_stop_finder",
+    "schemas",
+]

--- a/src/suedtirolmobilai/handlers.py
+++ b/src/suedtirolmobilai/handlers.py
@@ -1,0 +1,133 @@
+"""Handlers that normalize raw EFA payloads into application level schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+from .schemas import Departure, NormalizedError, RealtimeInfo, StopLocation
+
+
+def _ensure_iterable(points: Any) -> Iterable[MutableMapping[str, Any]]:
+    if points is None:
+        return []
+    if isinstance(points, Mapping):
+        return [points]  # type: ignore[list-item]
+    return points  # type: ignore[return-value]
+
+
+def normalize_stop_finder(payload: Mapping[str, Any]) -> List[StopLocation]:
+    """Normalize the response coming from the EFA stopFinder endpoint."""
+
+    stop_finder = payload.get("stopFinder", {})
+    points = stop_finder.get("points", {}).get("point")
+    point_items = list(_ensure_iterable(points))
+
+    best_score = max((int(item.get("matchQuality", 0)) for item in point_items), default=0)
+    normalized: List[StopLocation] = []
+
+    for item in point_items:
+        ref = item.get("ref", {})
+        coord = item.get("coord", {})
+        match_score = int(item.get("matchQuality", 0))
+        normalized.append(
+            StopLocation(
+                id=str(ref.get("id") or ref.get("extId") or ref.get("gid")),
+                gid=ref.get("gid"),
+                name=ref.get("name", ""),
+                type=str(ref.get("type", "stop")),
+                latitude=float(coord.get("lat")),
+                longitude=float(coord.get("lon")),
+                match_score=match_score,
+                is_best_match=match_score == best_score,
+                products=item.get("productCategories", []),
+            )
+        )
+
+    return normalized
+
+
+def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    return datetime.fromisoformat(value)
+
+
+def normalize_departure_monitor(payload: Mapping[str, Any]) -> List[Departure]:
+    """Normalize a departureMonitor/arrivalMonitor response."""
+
+    monitor = payload.get("monitor", {})
+    entries = list(_ensure_iterable(monitor.get("journeys")))
+    movement_type = str(monitor.get("type", "departures")).lower()
+
+    normalized: List[Departure] = []
+    for entry in entries:
+        planned_time = _parse_datetime(entry.get("scheduledTime"))
+        realtime_time = _parse_datetime(entry.get("realtimeTime"))
+        realtime_source = entry.get("realtimeSource")
+        realtime_updated = _parse_datetime(entry.get("lastUpdated"))
+
+        delay_seconds: int = 0
+        is_realtime = bool(entry.get("realtime", False) and realtime_time)
+        if planned_time and realtime_time:
+            delay_seconds = int((realtime_time - planned_time).total_seconds())
+        remarks = entry.get("remarks") or []
+
+        normalized.append(
+            Departure(
+                id=str(entry.get("id")),
+                line=str(entry.get("servingLine", {}).get("name")),
+                direction=str(entry.get("direction")),
+                planned_time=planned_time,
+                estimated_time=realtime_time,
+                platform=entry.get("platform"),
+                movement_type="arrival" if movement_type == "arrivals" else "departure",
+                realtime=RealtimeInfo(
+                    is_realtime=is_realtime,
+                    delay_seconds=delay_seconds,
+                    source=realtime_source,
+                    updated_at=realtime_updated,
+                ),
+                remarks=list(remarks),
+            )
+        )
+
+    return normalized
+
+
+_ERROR_CATEGORY_MAP: Dict[str, str] = {
+    "H430": "not_found",
+    "H895": "not_found",
+    "H730": "unavailable",
+    "H931": "unavailable",
+    "H922": "invalid_request",
+}
+
+_DEFAULT_MESSAGES: Dict[str, str] = {
+    "H430": "Stop could not be resolved",
+    "H730": "Upstream realtime data source is temporarily unavailable",
+    "H922": "The request contained invalid parameters",
+}
+
+
+def map_error_response(payload: Mapping[str, Any]) -> NormalizedError:
+    """Map a raw error payload into a :class:`NormalizedError`."""
+
+    error_block = payload.get("error") or payload.get("serviceError")
+    if not error_block:
+        raise ValueError("Payload does not contain an error section")
+
+    code = str(error_block.get("code") or error_block.get("id") or "UNKNOWN")
+    message = error_block.get("message") or error_block.get("text") or ""
+
+    category = _ERROR_CATEGORY_MAP.get(code, "unknown")
+    default_message = _DEFAULT_MESSAGES.get(code, "Unexpected response from EFA backend")
+    final_message = message.strip() or default_message
+
+    details = {
+        key: value
+        for key, value in error_block.items()
+        if key not in {"code", "id", "message", "text"}
+    }
+
+    return NormalizedError(code=code, category=category, message=final_message, details=details)

--- a/src/suedtirolmobilai/schemas.py
+++ b/src/suedtirolmobilai/schemas.py
@@ -1,0 +1,92 @@
+"""Pydantic schemas for normalized responses coming from the EFA backend."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class StopLocation(BaseModel):
+    """Normalized representation of a stop finder point."""
+
+    id: str = Field(..., description="Stable identifier for the stop or location")
+    gid: Optional[str] = Field(
+        default=None, description="Global identifier provided by EFA when available"
+    )
+    name: str = Field(..., description="Human readable stop name")
+    type: Literal["stop", "address", "poi"] = Field(..., description="Location type")
+    latitude: float = Field(..., ge=-90, le=90)
+    longitude: float = Field(..., ge=-180, le=180)
+    match_score: int = Field(..., ge=0, le=100, description="0-100 fuzzy match score")
+    is_best_match: bool = Field(
+        default=False, description="True when the entry is the best match for the query"
+    )
+    products: List[str] = Field(
+        default_factory=list, description="Transit products that serve this stop"
+    )
+
+    @field_validator("products", mode="before")
+    @classmethod
+    def _coerce_products(cls, value: Any) -> List[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        return list(value)
+
+
+class RealtimeInfo(BaseModel):
+    """Realtime metadata for a departure/arrival."""
+
+    is_realtime: bool = Field(
+        default=False, description="Whether realtime data was present for the journey"
+    )
+    delay_seconds: int = Field(
+        default=0, description="Delay in seconds (negative values indicate an early trip)"
+    )
+    source: Optional[str] = Field(default=None, description="Realtime provider identifier")
+    updated_at: Optional[datetime] = Field(
+        default=None, description="Timestamp of the realtime measurement"
+    )
+
+
+class Departure(BaseModel):
+    """Normalized departure or arrival entry."""
+
+    id: str = Field(..., description="Journey identifier")
+    line: str = Field(..., description="Public short name of the line")
+    direction: str = Field(..., description="Destination headsign")
+    planned_time: datetime = Field(..., description="Scheduled departure time in ISO-8601")
+    estimated_time: Optional[datetime] = Field(
+        default=None, description="Realtime updated time when available"
+    )
+    platform: Optional[str] = Field(default=None, description="Platform or stand information")
+    movement_type: Literal["departure", "arrival"] = Field(
+        ..., description="Whether the entry represents a departure or arrival"
+    )
+    realtime: RealtimeInfo = Field(..., description="Realtime metadata for the entry")
+    remarks: List[str] = Field(
+        default_factory=list, description="Optional textual remarks accompanying the entry"
+    )
+
+    @field_validator("planned_time", "estimated_time", mode="before")
+    @classmethod
+    def _ensure_datetime(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            return datetime.fromisoformat(value)
+        raise TypeError("Datetime fields must be provided as ISO strings or datetimes")
+
+
+class NormalizedError(BaseModel):
+    """Normalized error structure derived from EFA error payloads."""
+
+    code: str = Field(..., description="Underlying EFA error code")
+    category: Literal["not_found", "unavailable", "invalid_request", "unknown"]
+    message: str = Field(..., description="Human readable error message")
+    details: Dict[str, Any] = Field(default_factory=dict)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+from typing import Any, Callable, Dict
+
+import pytest
+
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def load_fixture() -> Callable[[str], Dict[str, Any]]:
+    def _load(name: str) -> Dict[str, Any]:
+        path = _FIXTURE_DIR / name
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    return _load

--- a/tests/fixtures/departure_monitor_arrivals.json
+++ b/tests/fixtures/departure_monitor_arrivals.json
@@ -1,0 +1,19 @@
+{
+  "monitor": {
+    "type": "arrivals",
+    "journeys": [
+      {
+        "id": "journey:3",
+        "servingLine": {"name": "SAD 200", "number": "200", "product": "bus"},
+        "direction": "Bolzano",
+        "platform": "1",
+        "scheduledTime": "2023-09-19T07:40:00+02:00",
+        "realtimeTime": "2023-09-19T07:39:00+02:00",
+        "realtime": true,
+        "realtimeSource": "efa-realtime",
+        "lastUpdated": "2023-09-19T07:38:15+02:00",
+        "remarks": ["Service operating ahead of schedule"]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/departure_monitor_departures.json
+++ b/tests/fixtures/departure_monitor_departures.json
@@ -1,0 +1,28 @@
+{
+  "monitor": {
+    "type": "departures",
+    "journeys": [
+      {
+        "id": "journey:1",
+        "servingLine": {"name": "SAD 100", "number": "100", "product": "bus"},
+        "direction": "Merano",
+        "platform": "2",
+        "scheduledTime": "2023-09-19T07:15:00+02:00",
+        "realtimeTime": "2023-09-19T07:17:00+02:00",
+        "realtime": true,
+        "realtimeSource": "efa-realtime",
+        "lastUpdated": "2023-09-19T07:14:30+02:00",
+        "remarks": ["Barrier-free vehicle"]
+      },
+      {
+        "id": "journey:2",
+        "servingLine": {"name": "SAD 201", "number": "201", "product": "bus"},
+        "direction": "Bolzano",
+        "platform": "A",
+        "scheduledTime": "2023-09-19T07:20:00+02:00",
+        "realtime": false,
+        "remarks": []
+      }
+    ]
+  }
+}

--- a/tests/fixtures/error_response_unavailable.json
+++ b/tests/fixtures/error_response_unavailable.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "H730",
+    "message": "Backend temporarily unavailable",
+    "httpStatus": 503
+  }
+}

--- a/tests/fixtures/error_response_unknown.json
+++ b/tests/fixtures/error_response_unknown.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "X999",
+    "message": "An undocumented error occurred",
+    "requestId": "abc-123"
+  }
+}

--- a/tests/fixtures/stop_finder_success.json
+++ b/tests/fixtures/stop_finder_success.json
@@ -1,0 +1,36 @@
+{
+  "stopFinder": {
+    "points": {
+      "point": [
+        {
+          "ref": {
+            "id": "1001",
+            "gid": "de:altoadige:1001",
+            "name": "Bolzano, Bahnhof",
+            "type": "stop"
+          },
+          "coord": {
+            "lat": 46.498295,
+            "lon": 11.354758
+          },
+          "matchQuality": 100,
+          "productCategories": ["train", "bus"]
+        },
+        {
+          "ref": {
+            "id": "1002",
+            "gid": "de:altoadige:1002",
+            "name": "Bolzano, Waltherplatz",
+            "type": "stop"
+          },
+          "coord": {
+            "lat": 46.49892,
+            "lon": 11.35796
+          },
+          "matchQuality": 92,
+          "productCategories": ["bus"]
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_departure_monitor.py
+++ b/tests/test_departure_monitor.py
@@ -1,0 +1,40 @@
+from datetime import timedelta
+
+from suedtirolmobilai.handlers import normalize_departure_monitor
+from suedtirolmobilai.schemas import Departure
+
+
+def test_departure_monitor_realtime_flags(load_fixture):
+    payload = load_fixture("departure_monitor_departures.json")
+    departures = normalize_departure_monitor(payload)
+
+    assert len(departures) == 2
+    for item in departures:
+        validated = Departure.model_validate(item.model_dump())
+        assert validated == item
+
+    realtime_departure = departures[0]
+    assert realtime_departure.movement_type == "departure"
+    assert realtime_departure.realtime.is_realtime is True
+    assert realtime_departure.realtime.delay_seconds == 120
+    assert realtime_departure.estimated_time == realtime_departure.planned_time + timedelta(
+        minutes=2
+    )
+    assert realtime_departure.realtime.source == "efa-realtime"
+
+    scheduled_only = departures[1]
+    assert scheduled_only.realtime.is_realtime is False
+    assert scheduled_only.estimated_time is None
+    assert scheduled_only.realtime.delay_seconds == 0
+
+
+def test_arrival_monitor_behaviour(load_fixture):
+    payload = load_fixture("departure_monitor_arrivals.json")
+    arrivals = normalize_departure_monitor(payload)
+
+    assert len(arrivals) == 1
+    arrival = arrivals[0]
+    assert arrival.movement_type == "arrival"
+    assert arrival.realtime.is_realtime is True
+    assert arrival.realtime.delay_seconds == -60
+    assert arrival.estimated_time == arrival.planned_time + timedelta(minutes=-1)

--- a/tests/test_error_mapping.py
+++ b/tests/test_error_mapping.py
@@ -1,0 +1,27 @@
+import pytest
+
+from suedtirolmobilai.handlers import map_error_response
+from suedtirolmobilai.schemas import NormalizedError
+
+
+def test_error_mapping_unavailable(load_fixture):
+    payload = load_fixture("error_response_unavailable.json")
+    normalized = map_error_response(payload)
+    validated = NormalizedError.model_validate(normalized.model_dump())
+    assert validated == normalized
+    assert normalized.category == "unavailable"
+    assert normalized.message == "Backend temporarily unavailable"
+    assert normalized.details == {"httpStatus": 503}
+
+
+def test_error_mapping_unknown_code(load_fixture):
+    payload = load_fixture("error_response_unknown.json")
+    normalized = map_error_response(payload)
+    assert normalized.category == "unknown"
+    assert normalized.message == "An undocumented error occurred"
+    assert normalized.details == {"requestId": "abc-123"}
+
+
+def test_error_mapping_missing_section_raises():
+    with pytest.raises(ValueError):
+        map_error_response({})

--- a/tests/test_stop_finder.py
+++ b/tests/test_stop_finder.py
@@ -1,0 +1,47 @@
+from suedtirolmobilai.handlers import normalize_stop_finder
+from suedtirolmobilai.schemas import StopLocation
+
+
+def test_stop_finder_results_validate_against_schema(load_fixture):
+    payload = load_fixture("stop_finder_success.json")
+    results = normalize_stop_finder(payload)
+
+    assert len(results) == 2
+    for item in results:
+        validated = StopLocation.model_validate(item.model_dump())
+        assert validated == item
+
+    assert results[0].is_best_match is True
+    assert results[0].match_score == 100
+    assert results[1].is_best_match is False
+
+
+def test_stop_finder_contract_snapshot(load_fixture):
+    payload = load_fixture("stop_finder_success.json")
+    results = normalize_stop_finder(payload)
+
+    snapshot = [item.model_dump() for item in results]
+    assert snapshot == [
+        {
+            "id": "1001",
+            "gid": "de:altoadige:1001",
+            "name": "Bolzano, Bahnhof",
+            "type": "stop",
+            "latitude": 46.498295,
+            "longitude": 11.354758,
+            "match_score": 100,
+            "is_best_match": True,
+            "products": ["train", "bus"],
+        },
+        {
+            "id": "1002",
+            "gid": "de:altoadige:1002",
+            "name": "Bolzano, Waltherplatz",
+            "type": "stop",
+            "latitude": 46.49892,
+            "longitude": 11.35796,
+            "match_score": 92,
+            "is_best_match": False,
+            "products": ["bus"],
+        },
+    ]


### PR DESCRIPTION
## Summary
- add a setuptools-based Python package with Pydantic schemas for normalised EFA responses
- implement handler utilities for stop finder, monitor and error payloads
- record representative EFA fixtures and introduce pytest contract tests plus CI workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd4b587b1c8321aea9b20629af6ca9